### PR TITLE
feat(nvim-powershell): add powershell.nvim plugin configuration

### DIFF
--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/powershell.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/powershell.lua
@@ -12,10 +12,8 @@ if vim.fn.executable('powershell') == 0 or vim.fn.executable('pwsh') == 0 then
   return M
 end
 
-M.lspconfigs = { LspConfig:new('powershell_es', 'powershell-editor-services') }
+local powershell_es = LspConfig:new(nil, 'powershell-editor-services')
+
+M.lspconfigs = { powershell_es }
 
 return M
-
--- TODO: configure DAP
--- https://github.com/TheLeoP/powershell.nvim?tab=readme-ov-file#dap
---

--- a/home/.chezmoitemplates/nvim/lua/plugins/powershell.lua
+++ b/home/.chezmoitemplates/nvim/lua/plugins/powershell.lua
@@ -1,0 +1,10 @@
+return {
+  'TheLeoP/powershell.nvim',
+  config = function()
+    require('powershell').setup({
+      -- https://github.com/TheLeoP/powershell.nvim?tab=readme-ov-file#configuration
+      -- https://github.com/mason-org/mason.nvim/blob/main/CHANGELOG.md#package-api-changes
+      bundle_path = vim.fn.expand('$MASON/packages/powershell-editor-services'),
+    })
+  end,
+}


### PR DESCRIPTION
Refactor powershell LSP config and integrate `TheLeoP/powershell.nvim` plugin. This includes setting up the plugin with `mason.nvim` for bundle path management, enhancing Neovim's PowerShell language support.