### PR TITLE
refactor(keybindings): reorganize Neovim and IdeaVim keymaps

### DIFF
--- a/home/.chezmoitemplates/nvim/lua/configs/vscode.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/vscode.lua
@@ -23,28 +23,38 @@ vim.keymap.set('n', 'bj', ':Tabprevious<CR>', opts.nore)
 vim.keymap.set('n', 'bk', ':Tabnext<CR>', opts.nore)
 vim.keymap.set('n', 'bc', ':Tabclose<CR>', opts.nore)
 
-vim.keymap.set('n', 'tt', "<Cmd>call VSCodeNotify('workbench.view.explorer')<CR>", opts.nore)
+vim.keymap.set(
+  'n',
+  '<leader>tt',
+  "<Cmd>call VSCodeNotify('workbench.view.explorer')<CR>",
+  opts.nore
+)
 vim.keymap.set('n', '<leader>/', "<Cmd>call VSCodeNotify('actions.find')<CR>", opts.nore)
 
 -- Telescope
 vim.keymap.set(
   'n',
-  '<leader>ff',
+  '<leader>sf',
   "<Cmd>call VSCodeNotify('workbench.action.quickOpen')<CR>",
   opts.nore
 )
 vim.keymap.set(
   'n',
-  '<leader>fg',
+  '<leader>sg',
   "<Cmd>call VSCodeNotify('workbench.action.findInFiles')<CR>",
   opts.nore
 )
 
 -- LSP
-vim.keymap.set('n', '<leader>rn', "<Cmd>call VSCodeNotify('editor.action.rename')<CR>", opts.nore)
-vim.keymap.set('n', '<leader>ca', "<Cmd>call VSCodeNotify('editor.action.quickFix')<CR>", opts.nore)
-vim.keymap.set('n', 'gd', "<Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>", opts.nore)
-vim.keymap.set('n', 'gr', "<Cmd>call VSCodeNotify('editor.action.goToReferences')<CR>", opts.nore)
+vim.keymap.set('n', 'grn', "<Cmd>call VSCodeNotify('editor.action.rename')<CR>", opts.nore)
+vim.keymap.set('n', 'gra', "<Cmd>call VSCodeNotify('editor.action.quickFix')<CR>", opts.nore)
+vim.keymap.set(
+  'n',
+  'grd',
+  "<Cmd>call VSCodeNotify('editor.action.revealDefinition')<CR>",
+  opts.nore
+)
+vim.keymap.set('n', 'grr', "<Cmd>call VSCodeNotify('editor.action.goToReferences')<CR>", opts.nore)
 vim.keymap.set(
   'n',
   '[d',

--- a/home/dot_ideavimrc
+++ b/home/dot_ideavimrc
@@ -29,21 +29,21 @@ inoremap <A-h> <Esc>i
 inoremap <A-l> <Esc>la
 
 " Telescope fzf like keymap 
-noremap <leader>ff :action GotoFile<CR>
-noremap <leader>fg :action SearchEverywhere<CR>
-noremap <leader>fw :action TextSearchAction<CR>
+noremap <leader>sf :action GotoFile<CR>
+noremap <leader>sg :action SearchEverywhere<CR>
+noremap <leader>sw :action TextSearchAction<CR>
 noremap <leader>/ :action Find<CR>
-noremap <leader>ds :action ActivateStructureToolWindow<CR>
-noremap <leader>ws :action GotoSymbol<CR>
+" noremap <leader>ds :action ActivateStructureToolWindow<CR>
 noremap <leader><space> :action Switcher<CR>
 
 " Nvim lsp like keymap
-noremap <leader>rn :action RenameElement<CR>
-noremap <leader>ca :action ShowIntentionActions<CR>
-noremap gd :action GotoDeclaration<CR>
-noremap <leader>D :action GotoTypeDeclaration<CR>
-noremap gr :action ShowUsages<CR>
-noremap gI :action ReSharperGotoImplementation<CR>
+noremap grn :action RenameElement<CR>
+noremap gra :action ShowIntentionActions<CR>
+noremap grd :action GotoDeclaration<CR>
+noremap grr :action ShowUsages<CR>
+noremap grt :action GotoTypeDeclaration<CR>
+noremap gri :action ReSharperGotoImplementation<CR>
+noremap gO :action GotoSymbol<CR>
 
 " Diagnostic keymap 
 noremap [d :action GotoNextError<CR>
@@ -77,9 +77,10 @@ noremap <C-p> :action EditorPaste<CR>
 " noremap <C-z> :action ToggleDistractionFreeMode<CR>
 noremap <leader>tt :action ActivateProjectToolWindow<CR>
 noremap sb :action ActivateBuildToolWindow<CR>
-noremap <leader>gs :action ActivateVersionControlToolWindow<CR>
 noremap <C-\> :action ActivateTerminalToolWindow<CR>
 
+" Git
+noremap <leader>gs :action ActivateVersionControlToolWindow<CR>
 noremap <leader>gu :action Vcs.UpdateProject<CR>
 noremap <leader>gf :action Git.Fetch<CR>
 noremap <leader>gc :action CheckinProject<CR> 


### PR DESCRIPTION
Refactor keybindings in Neovim and IdeaVim configurations for improved consistency and organization.

- LSP-related keybindings now use a `gr` prefix (e.g., `grn` for rename, `gra` for quickfix).
- Search/file-related keybindings now use an `s` prefix (e.g., `sf` for quick open, `sg` for find in files).
- Added a new "Git" section to `home/dot_ideavimrc` with relevant keymaps.