### PR TITLE
feat(nvim): add indent-blankline plugin for better code visualization

### DIFF
--- a/home/.chezmoitemplates/nvim/lua/plugins/indent-blankline.lua
+++ b/home/.chezmoitemplates/nvim/lua/plugins/indent-blankline.lua
@@ -1,0 +1,11 @@
+return {
+  'lukas-reineke/indent-blankline.nvim',
+  main = 'ibl',
+  ---@module "ibl"
+  ---@type ibl.config
+  opts = {
+    indent = {
+      char = '╎',
+    },
+  },
+}

--- a/home/.chezmoitemplates/nvim/lua/plugins/mini.lua
+++ b/home/.chezmoitemplates/nvim/lua/plugins/mini.lua
@@ -7,7 +7,7 @@ return { -- Collection of various small independent plugins/modules
     --  - va)  - [V]isually select [A]round [)]paren
     --  - yinq - [Y]ank [I]nside [N]ext [Q]uote
     --  - ci'  - [C]hange [I]nside [']quote
-    require('mini.ai').setup { n_lines = 500 }
+    require('mini.ai').setup({ n_lines = 500 })
 
     -- Add/delete/replace surroundings (brackets, quotes, etc.)
     --


### PR DESCRIPTION
Add lukas-reineke/indent-blankline.nvim plugin to enhance code readability with visual indentation guides using '╎' character. Also improve code style consistency in mini.ai setup by adding explicit parentheses around configuration object.