### PR TITLE
refactor(nvim): modernize LSP codelens handling

### DIFF
--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/lua.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/lua.lua
@@ -4,9 +4,7 @@ local M = LanguageSetting:new()
 
 M.treesitter.filetypes = { 'lua' }
 
--- TODO: https://github.com/folke/lazydev.nvim/issues/136#issuecomment-3773651709
-local lua_ls =
-  LspConfig:new('lua_ls', { 'lua-language-server', version = '3.16.4', auto_update = false })
+local lua_ls = LspConfig:new('lua_ls', 'lua-language-server')
 lua_ls.config = {
   settings = {
     Lua = {

--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
@@ -5,6 +5,7 @@ local LanguageSetting = require('configs.lsp.base')
 local LspConfig = require('configs.lsp.lspconfig')
 local log = require('utils.log')
 local lsp_codelens = require('utils.lsp_codelens')
+local Methods = vim.lsp.protocol.Methods
 
 local M = LanguageSetting:new()
 
@@ -46,6 +47,7 @@ local CMD = {
 -- State
 local commands_registered = false
 local indexing_in_progress = false
+---@type table<integer, table<integer, true>>
 local active_clients = {}
 ---@type table<integer, dotfiles.IntelephenseUnusedRefsState>
 local unused_refs_states = {}
@@ -189,7 +191,26 @@ local function get_symbol_at(bufnr, line, col)
   return text:match('^%$?[%w_]+')
 end
 
-local function set_unused_reference_diagnostics(bufnr, client_id, lenses)
+---@param bufnr integer
+---@param lens lsp.CodeLens
+---@param client vim.lsp.Client
+---@return integer
+local function lens_start_col(bufnr, lens, client)
+  local ok, range = pcall(function()
+    return vim.range.lsp(bufnr, lens.range, client.offset_encoding)
+  end)
+  if ok and range and type(range.start_col) == 'number' then
+    return range.start_col
+  end
+
+  return lens.range.start.character
+end
+
+---@param bufnr integer
+---@param client vim.lsp.Client
+---@param lenses lsp.CodeLens[]?
+local function set_unused_reference_diagnostics(bufnr, client, lenses)
+  local client_id = client.id
   -- Lines with existing intelephense diagnostics
   local existing =
     vim.diagnostic.get(bufnr, { namespace = vim.lsp.diagnostic.get_namespace(client_id) })
@@ -205,10 +226,11 @@ local function set_unused_reference_diagnostics(bufnr, client_id, lenses)
     if cmd and cmd.title and cmd.title:match('^0 References') then
       local pos = lens.range.start
       if not has_existing or not diag_lines[pos.line] then
-        local symbol = get_symbol_at(bufnr, pos.line, pos.character) or 'symbol'
+        local col = lens_start_col(bufnr, lens, client)
+        local symbol = get_symbol_at(bufnr, pos.line, col) or 'symbol'
         acc[#acc + 1] = {
           lnum = pos.line,
-          col = pos.character,
+          col = col,
           message = ("Symbol '%s' is declared but not used."):format(symbol),
           severity = vim.diagnostic.severity.HINT,
           source = 'intelephense',
@@ -257,6 +279,16 @@ local function clear_unused_reference_state(bufnr, state)
 end
 
 ---@param bufnr integer
+---@param state dotfiles.IntelephenseUnusedRefsState
+---@param seq integer
+---@return boolean
+local function is_unused_reference_refresh_current(bufnr, state, seq)
+  return vim.api.nvim_buf_is_valid(bufnr)
+    and unused_refs_states[bufnr] == state
+    and state.refresh_seq == seq
+end
+
+---@param bufnr integer
 ---@param client_id integer
 ---@return lsp.CodeLens[]
 local function get_cached_codelenses(bufnr, client_id)
@@ -299,21 +331,47 @@ local function codelens_cache_key(lenses)
   return table.concat(parts, '|')
 end
 
+---@param client_id integer
+---@param bufnr integer
+local function track_active_client_buffer(client_id, bufnr)
+  local bufnrs = active_clients[client_id] or {}
+  bufnrs[bufnr] = true
+  active_clients[client_id] = bufnrs
+end
+
+---@param bufnr integer
+---@param client vim.lsp.Client
+---@param state dotfiles.IntelephenseUnusedRefsState
+---@param seq integer
+local function request_unused_reference_diagnostics(bufnr, client, state, seq)
+  local params = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
+  client:request(Methods.textDocument_codeLens, params, function(err, lenses)
+    if not is_unused_reference_refresh_current(bufnr, state, seq) then
+      return
+    end
+
+    state.timer = nil
+    if err then
+      clear_unused_reference_diagnostics(bufnr)
+      return
+    end
+
+    set_unused_reference_diagnostics(bufnr, client, lenses)
+  end, bufnr)
+end
+
 ---@param bufnr integer
 ---@param state dotfiles.IntelephenseUnusedRefsState
 ---@param seq integer
 ---@param initial_cache_key string
 ---@param remaining_ms integer
 local function refresh_unused_reference_diagnostics_from_cache(bufnr, state, seq, initial_cache_key, remaining_ms)
-  if not vim.api.nvim_buf_is_valid(bufnr) or unused_refs_states[bufnr] ~= state or state.refresh_seq ~= seq then
+  if not is_unused_reference_refresh_current(bufnr, state, seq) then
     return
   end
 
   local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'intelephense' })[1]
-  if
-    not client
-    or not client:supports_method(vim.lsp.protocol.Methods.textDocument_codeLens, bufnr)
-  then
+  if not client or not client:supports_method(Methods.textDocument_codeLens, bufnr) then
     state.timer = nil
     clear_unused_reference_diagnostics(bufnr)
     return
@@ -321,9 +379,17 @@ local function refresh_unused_reference_diagnostics_from_cache(bufnr, state, seq
 
   local lenses = get_cached_codelenses(bufnr, client.id)
   local cache_key = codelens_cache_key(lenses)
-  if cache_key ~= initial_cache_key or remaining_ms <= 0 then
+  if cache_key ~= initial_cache_key then
     state.timer = nil
-    set_unused_reference_diagnostics(bufnr, client.id, lenses)
+    set_unused_reference_diagnostics(bufnr, client, lenses)
+    return
+  end
+
+  if remaining_ms <= 0 then
+    state.timer = nil
+    -- Cache keys can legitimately stay identical across refreshes, so use one
+    -- direct request here instead of treating "unchanged cache" as "stale data".
+    request_unused_reference_diagnostics(bufnr, client, state, seq)
     return
   end
 
@@ -394,8 +460,8 @@ local function attach_unused_reference_updates_once(bufnr)
 end
 
 local function has_active_client_in_buffer(bufnr)
-  for _, active_bufnr in pairs(active_clients) do
-    if active_bufnr == bufnr then
+  for _, active_bufnrs in pairs(active_clients) do
+    if active_bufnrs[bufnr] then
       return true
     end
   end
@@ -425,8 +491,8 @@ intelephense.config = {
   },
 
   on_attach = function(client, bufnr)
-    active_clients[client.id] = bufnr
-    if client:supports_method(vim.lsp.protocol.Methods.textDocument_codeLens, bufnr) then
+    track_active_client_buffer(client.id, bufnr)
+    if client:supports_method(Methods.textDocument_codeLens, bufnr) then
       attach_unused_reference_updates_once(bufnr)
       local state = unused_refs_states[bufnr]
       if state then
@@ -438,13 +504,15 @@ intelephense.config = {
 
   -- LSP on_exit may run in a fast event; schedule all editor-state cleanup.
   on_exit = vim.schedule_wrap(function(_, _, client_id)
-    local bufnr = active_clients[client_id]
+    local bufnrs = active_clients[client_id] or {}
     active_clients[client_id] = nil
 
-    if bufnr and not has_active_client_in_buffer(bufnr) then
-      clear_unused_reference_state(bufnr)
-      if vim.api.nvim_buf_is_valid(bufnr) then
-        clear_unused_reference_diagnostics(bufnr)
+    for bufnr in pairs(bufnrs) do
+      if not has_active_client_in_buffer(bufnr) then
+        clear_unused_reference_state(bufnr)
+        if vim.api.nvim_buf_is_valid(bufnr) then
+          clear_unused_reference_diagnostics(bufnr)
+        end
       end
     end
 

--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
@@ -39,8 +39,6 @@ local CMD = {
 -- State
 local commands_registered = false
 local indexing_in_progress = false
-local codelens_display_registered = false
-local original_codelens_display
 local active_clients = {}
 
 local function get_client()
@@ -167,6 +165,8 @@ end
 -- Unused Function Diagnostics (via Intelephense CodeLens)
 -- ============================================================================
 local unused_refs_ns = vim.api.nvim_create_namespace('intelephense_unused_refs')
+local unused_refs_augroup =
+  vim.api.nvim_create_augroup('intelephense-unused-refs', { clear = false })
 
 -- Extract symbol name from buffer at position
 local function get_symbol_at(bufnr, line, col)
@@ -179,74 +179,89 @@ local function get_symbol_at(bufnr, line, col)
   return text:match('^%$?[%w_]+')
 end
 
-local function register_codelens_display_once()
-  if codelens_display_registered then
-    return
-  end
+local function set_unused_reference_diagnostics(bufnr, client_id, lenses)
+  -- Lines with existing intelephense diagnostics
+  local existing =
+    vim.diagnostic.get(bufnr, { namespace = vim.lsp.diagnostic.get_namespace(client_id) })
+  local diag_lines = vim.iter(existing):fold({}, function(acc, d)
+    acc[d.lnum] = true
+    return acc
+  end)
+  local has_existing = next(diag_lines) ~= nil
 
-  original_codelens_display = vim.lsp.codelens.display
-  vim.lsp.codelens.display = function(lenses, bufnr, client_id)
-    original_codelens_display(lenses, bufnr, client_id)
-
-    local client = vim.lsp.get_client_by_id(client_id)
-    if not client or client.name ~= 'intelephense' then
-      return
-    end
-
-    vim.diagnostic.reset(unused_refs_ns, bufnr)
-    if not lenses or #lenses == 0 then
-      return
-    end
-
-    -- Lines with existing intelephense diagnostics
-    local existing =
-      vim.diagnostic.get(bufnr, { namespace = vim.lsp.diagnostic.get_namespace(client_id) })
-    local diag_lines = vim.iter(existing):fold({}, function(acc, d)
-      acc[d.lnum] = true
-      return acc
-    end)
-    local has_existing = next(diag_lines) ~= nil
-
-    -- Single pass: filter + map in one fold (3x fewer function calls)
-    local diagnostics = vim.iter(lenses):fold({}, function(acc, lens)
-      local cmd = lens.command
-      if cmd and cmd.title and cmd.title:match('^0 References') then
-        local pos = lens.range.start
-        if not has_existing or not diag_lines[pos.line] then
-          local symbol = get_symbol_at(bufnr, pos.line, pos.character) or 'symbol'
-          acc[#acc + 1] = {
-            lnum = pos.line,
-            col = pos.character,
-            message = ("Symbol '%s' is declared but not used."):format(symbol),
-            severity = vim.diagnostic.severity.HINT,
-            source = 'intelephense',
-            code = 'P1003',
-          }
-        end
+  -- Single pass: filter + map in one fold (3x fewer function calls)
+  local diagnostics = vim.iter(lenses or {}):fold({}, function(acc, lens)
+    local cmd = lens.command
+    if cmd and cmd.title and cmd.title:match('^0 References') then
+      local pos = lens.range.start
+      if not has_existing or not diag_lines[pos.line] then
+        local symbol = get_symbol_at(bufnr, pos.line, pos.character) or 'symbol'
+        acc[#acc + 1] = {
+          lnum = pos.line,
+          col = pos.character,
+          message = ("Symbol '%s' is declared but not used."):format(symbol),
+          severity = vim.diagnostic.severity.HINT,
+          source = 'intelephense',
+          code = 'P1003',
+        }
       end
-      return acc
-    end)
+    end
+    return acc
+  end)
 
-    vim.diagnostic.set(unused_refs_ns, bufnr, diagnostics)
-  end
-
-  codelens_display_registered = true
+  vim.diagnostic.set(unused_refs_ns, bufnr, diagnostics)
 end
 
-local function unregister_codelens_display()
-  if not codelens_display_registered then
+local function refresh_unused_reference_diagnostics(client, bufnr)
+  if
+    client.name ~= 'intelephense'
+    or not vim.api.nvim_buf_is_valid(bufnr)
+    or not client:supports_method(vim.lsp.protocol.Methods.textDocument_codeLens, bufnr)
+  then
     return
   end
 
-  if original_codelens_display then
-    vim.lsp.codelens.display = original_codelens_display
-  end
-  codelens_display_registered = false
+  local tick = vim.api.nvim_buf_get_changedtick(bufnr)
+  local params = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
+  client:request(vim.lsp.protocol.Methods.textDocument_codeLens, params, function(err, result)
+    if err or not vim.api.nvim_buf_is_valid(bufnr) then
+      return
+    end
 
-  -- Schedule: diagnostic.reset uses buf API, unsafe in fast-event context
-  vim.schedule(function()
-    vim.diagnostic.reset(unused_refs_ns)
-  end)
+    if vim.api.nvim_buf_get_changedtick(bufnr) ~= tick then
+      return
+    end
+
+    set_unused_reference_diagnostics(bufnr, client.id, result)
+  end, bufnr)
+end
+
+local function register_unused_reference_autocmd_once(bufnr)
+  if vim.b[bufnr].intelephense_unused_refs_autocmd then
+    return
+  end
+
+  vim.b[bufnr].intelephense_unused_refs_autocmd = true
+  vim.api.nvim_create_autocmd({ 'InsertLeave', 'BufWritePost' }, {
+    buffer = bufnr,
+    group = unused_refs_augroup,
+    callback = function()
+      local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'intelephense' })[1]
+      if client then
+        refresh_unused_reference_diagnostics(client, bufnr)
+      end
+    end,
+  })
+end
+
+local function has_active_client_in_buffer(bufnr)
+  for _, active_bufnr in pairs(active_clients) do
+    if active_bufnr == bufnr then
+      return true
+    end
+  end
+
+  return false
 end
 
 intelephense.config = {
@@ -270,16 +285,32 @@ intelephense.config = {
     ['indexingEnded'] = on_indexing_ended,
   },
 
-  on_attach = function(client, _)
-    active_clients[client.id] = true
-    register_codelens_display_once()
+  on_attach = function(client, bufnr)
+    active_clients[client.id] = bufnr
+    if client:supports_method(vim.lsp.protocol.Methods.textDocument_codeLens, bufnr) then
+      register_unused_reference_autocmd_once(bufnr)
+      refresh_unused_reference_diagnostics(client, bufnr)
+    end
     register_commands_once()
   end,
 
   on_exit = function(_, _, client_id)
+    local bufnr = active_clients[client_id]
     active_clients[client_id] = nil
+
+    if bufnr and not has_active_client_in_buffer(bufnr) then
+      pcall(vim.api.nvim_clear_autocmds, { group = unused_refs_augroup, buffer = bufnr })
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        vim.b[bufnr].intelephense_unused_refs_autocmd = nil
+      end
+      vim.schedule(function()
+        if vim.api.nvim_buf_is_valid(bufnr) then
+          vim.diagnostic.set(unused_refs_ns, bufnr, {})
+        end
+      end)
+    end
+
     if next(active_clients) == nil then
-      unregister_codelens_display()
       unregister_commands()
     end
   end,

--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
@@ -224,6 +224,8 @@ local function refresh_unused_reference_diagnostics(client, bufnr)
     return
   end
 
+  -- Request CodeLens directly so these hint diagnostics do not depend on which
+  -- renderer currently owns CodeLens output for the buffer.
   local tick = vim.api.nvim_buf_get_changedtick(bufnr)
   local params = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
   client:request(vim.lsp.protocol.Methods.textDocument_codeLens, params, function(err, result)

--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
@@ -29,6 +29,7 @@ local intelephense = LspConfig:new('intelephense', 'intelephense')
 local CACHE_PATH = vim.fn.stdpath('cache') .. '/intelephense'
 local STOP_TIMEOUT = 5000
 local POLL_INTERVAL = 50
+local UNUSED_REFS_REFRESH_DELAY_MS = 100
 
 local CMD = {
   INDEX = 'IntelephenseIndexWorkspace',
@@ -36,10 +37,15 @@ local CMD = {
   STATUS = 'IntelephenseStatus',
 }
 
+---@class dotfiles.IntelephenseUnusedRefsState
+---@field timer? uv.uv_timer_t
+
 -- State
 local commands_registered = false
 local indexing_in_progress = false
 local active_clients = {}
+---@type table<integer, dotfiles.IntelephenseUnusedRefsState>
+local unused_refs_states = {}
 
 local function get_client()
   return vim.lsp.get_clients({ name = 'intelephense' })[1]
@@ -168,8 +174,6 @@ end
 -- Unused Function Diagnostics (via Intelephense CodeLens)
 -- ============================================================================
 local unused_refs_ns = vim.api.nvim_create_namespace('intelephense_unused_refs')
-local unused_refs_augroup =
-  vim.api.nvim_create_augroup('intelephense-unused-refs', { clear = false })
 
 -- Extract symbol name from buffer at position
 local function get_symbol_at(bufnr, line, col)
@@ -215,6 +219,40 @@ local function set_unused_reference_diagnostics(bufnr, client_id, lenses)
   vim.diagnostic.set(unused_refs_ns, bufnr, diagnostics)
 end
 
+local function clear_unused_reference_diagnostics(bufnr)
+  if vim.api.nvim_buf_is_valid(bufnr) then
+    vim.diagnostic.set(unused_refs_ns, bufnr, {})
+  end
+end
+
+---@param state dotfiles.IntelephenseUnusedRefsState
+local function reset_unused_reference_refresh_timer(state)
+  local timer = state.timer
+  if not timer then
+    return
+  end
+
+  state.timer = nil
+  if timer:is_closing() then
+    return
+  end
+
+  timer:stop()
+  timer:close()
+end
+
+---@param bufnr integer
+---@param state? dotfiles.IntelephenseUnusedRefsState
+local function clear_unused_reference_state(bufnr, state)
+  local current_state = unused_refs_states[bufnr]
+  if not current_state or (state and current_state ~= state) then
+    return
+  end
+
+  reset_unused_reference_refresh_timer(current_state)
+  unused_refs_states[bufnr] = nil
+end
+
 local function refresh_unused_reference_diagnostics(client, bufnr)
   if
     client.name ~= 'intelephense'
@@ -241,22 +279,61 @@ local function refresh_unused_reference_diagnostics(client, bufnr)
   end, bufnr)
 end
 
-local function register_unused_reference_autocmd_once(bufnr)
-  if vim.b[bufnr].intelephense_unused_refs_autocmd then
+local function refresh_unused_reference_diagnostics_for_buffer(bufnr)
+  local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'intelephense' })[1]
+  if client then
+    refresh_unused_reference_diagnostics(client, bufnr)
+  end
+end
+
+---@param bufnr integer
+---@param state dotfiles.IntelephenseUnusedRefsState
+local function schedule_unused_reference_refresh(bufnr, state)
+  if not vim.api.nvim_buf_is_valid(bufnr) or unused_refs_states[bufnr] ~= state then
     return
   end
 
-  vim.b[bufnr].intelephense_unused_refs_autocmd = true
-  vim.api.nvim_create_autocmd({ 'InsertLeave', 'BufWritePost' }, {
-    buffer = bufnr,
-    group = unused_refs_augroup,
-    callback = function()
-      local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'intelephense' })[1]
-      if client then
-        refresh_unused_reference_diagnostics(client, bufnr)
+  reset_unused_reference_refresh_timer(state)
+  state.timer = vim.defer_fn(function()
+    if unused_refs_states[bufnr] ~= state then
+      return
+    end
+
+    state.timer = nil
+    refresh_unused_reference_diagnostics_for_buffer(bufnr)
+  end, UNUSED_REFS_REFRESH_DELAY_MS)
+end
+
+local function attach_unused_reference_updates_once(bufnr)
+  if unused_refs_states[bufnr] then
+    return
+  end
+
+  local state = {}
+  unused_refs_states[bufnr] = state
+  local attached = vim.api.nvim_buf_attach(bufnr, false, {
+    on_lines = function(_, buf)
+      if unused_refs_states[buf] ~= state then
+        return true
       end
+
+      schedule_unused_reference_refresh(buf, state)
+    end,
+    on_reload = function(_, buf)
+      if unused_refs_states[buf] ~= state then
+        return true
+      end
+
+      schedule_unused_reference_refresh(buf, state)
+    end,
+    on_detach = function(_, buf)
+      clear_unused_reference_state(buf, state)
     end,
   })
+
+  if not attached and unused_refs_states[bufnr] == state then
+    unused_refs_states[bufnr] = nil
+  end
 end
 
 local function has_active_client_in_buffer(bufnr)
@@ -293,7 +370,7 @@ intelephense.config = {
   on_attach = function(client, bufnr)
     active_clients[client.id] = bufnr
     if client:supports_method(vim.lsp.protocol.Methods.textDocument_codeLens, bufnr) then
-      register_unused_reference_autocmd_once(bufnr)
+      attach_unused_reference_updates_once(bufnr)
       refresh_unused_reference_diagnostics(client, bufnr)
     end
     register_commands_once()
@@ -305,10 +382,9 @@ intelephense.config = {
     active_clients[client_id] = nil
 
     if bufnr and not has_active_client_in_buffer(bufnr) then
-      pcall(vim.api.nvim_clear_autocmds, { group = unused_refs_augroup, buffer = bufnr })
+      clear_unused_reference_state(bufnr)
       if vim.api.nvim_buf_is_valid(bufnr) then
-        vim.b[bufnr].intelephense_unused_refs_autocmd = nil
-        vim.diagnostic.set(unused_refs_ns, bufnr, {})
+        clear_unused_reference_diagnostics(bufnr)
       end
     end
 

--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
@@ -4,6 +4,7 @@
 local LanguageSetting = require('configs.lsp.base')
 local LspConfig = require('configs.lsp.lspconfig')
 local log = require('utils.log')
+local lsp_codelens = require('utils.lsp_codelens')
 
 local M = LanguageSetting:new()
 
@@ -30,6 +31,7 @@ local CACHE_PATH = vim.fn.stdpath('cache') .. '/intelephense'
 local STOP_TIMEOUT = 5000
 local POLL_INTERVAL = 50
 local UNUSED_REFS_REFRESH_DELAY_MS = 100
+local UNUSED_REFS_CACHE_TIMEOUT_MS = 800
 
 local CMD = {
   INDEX = 'IntelephenseIndexWorkspace',
@@ -39,6 +41,7 @@ local CMD = {
 
 ---@class dotfiles.IntelephenseUnusedRefsState
 ---@field timer? uv.uv_timer_t
+---@field refresh_seq? integer
 
 -- State
 local commands_registered = false
@@ -253,37 +256,86 @@ local function clear_unused_reference_state(bufnr, state)
   unused_refs_states[bufnr] = nil
 end
 
-local function refresh_unused_reference_diagnostics(client, bufnr)
-  if
-    client.name ~= 'intelephense'
-    or not vim.api.nvim_buf_is_valid(bufnr)
-    or not client:supports_method(vim.lsp.protocol.Methods.textDocument_codeLens, bufnr)
-  then
+---@param bufnr integer
+---@param client_id integer
+---@return lsp.CodeLens[]
+local function get_cached_codelenses(bufnr, client_id)
+  local results
+  if lsp_codelens.is_active(bufnr) then
+    results = lsp_codelens.get({ bufnr = bufnr, client_id = client_id })
+  else
+    results = vim.lsp.codelens.get({ bufnr = bufnr, client_id = client_id })
+  end
+
+  local lenses = {}
+  for _, item in ipairs(results) do
+    local lens = item.lens or item
+    lenses[#lenses + 1] = lens
+  end
+
+  return lenses
+end
+
+---@param lenses lsp.CodeLens[]
+---@return string
+local function codelens_cache_key(lenses)
+  local parts = {}
+
+  for _, lens in ipairs(lenses) do
+    local range = lens.range or {}
+    local start_pos = range.start or {}
+    local end_pos = range['end'] or {}
+    local title = lens.command and lens.command.title or ''
+    parts[#parts + 1] = table.concat({
+      tostring(start_pos.line or -1),
+      tostring(start_pos.character or -1),
+      tostring(end_pos.line or -1),
+      tostring(end_pos.character or -1),
+      title,
+    }, ':')
+  end
+
+  table.sort(parts)
+  return table.concat(parts, '|')
+end
+
+---@param bufnr integer
+---@param state dotfiles.IntelephenseUnusedRefsState
+---@param seq integer
+---@param initial_cache_key string
+---@param remaining_ms integer
+local function refresh_unused_reference_diagnostics_from_cache(bufnr, state, seq, initial_cache_key, remaining_ms)
+  if not vim.api.nvim_buf_is_valid(bufnr) or unused_refs_states[bufnr] ~= state or state.refresh_seq ~= seq then
     return
   end
 
-  -- Request CodeLens directly so these hint diagnostics do not depend on which
-  -- renderer currently owns CodeLens output for the buffer.
-  local tick = vim.api.nvim_buf_get_changedtick(bufnr)
-  local params = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
-  client:request(vim.lsp.protocol.Methods.textDocument_codeLens, params, function(err, result)
-    if err or not vim.api.nvim_buf_is_valid(bufnr) then
-      return
-    end
-
-    if vim.api.nvim_buf_get_changedtick(bufnr) ~= tick then
-      return
-    end
-
-    set_unused_reference_diagnostics(bufnr, client.id, result)
-  end, bufnr)
-end
-
-local function refresh_unused_reference_diagnostics_for_buffer(bufnr)
   local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'intelephense' })[1]
-  if client then
-    refresh_unused_reference_diagnostics(client, bufnr)
+  if
+    not client
+    or not client:supports_method(vim.lsp.protocol.Methods.textDocument_codeLens, bufnr)
+  then
+    state.timer = nil
+    clear_unused_reference_diagnostics(bufnr)
+    return
   end
+
+  local lenses = get_cached_codelenses(bufnr, client.id)
+  local cache_key = codelens_cache_key(lenses)
+  if cache_key ~= initial_cache_key or remaining_ms <= 0 then
+    state.timer = nil
+    set_unused_reference_diagnostics(bufnr, client.id, lenses)
+    return
+  end
+
+  state.timer = vim.defer_fn(function()
+    refresh_unused_reference_diagnostics_from_cache(
+      bufnr,
+      state,
+      seq,
+      initial_cache_key,
+      remaining_ms - POLL_INTERVAL
+    )
+  end, POLL_INTERVAL)
 end
 
 ---@param bufnr integer
@@ -294,13 +346,18 @@ local function schedule_unused_reference_refresh(bufnr, state)
   end
 
   reset_unused_reference_refresh_timer(state)
+  state.refresh_seq = (state.refresh_seq or 0) + 1
+  local seq = state.refresh_seq
+  local client = vim.lsp.get_clients({ bufnr = bufnr, name = 'intelephense' })[1]
+  local initial_cache_key = client and codelens_cache_key(get_cached_codelenses(bufnr, client.id)) or ''
   state.timer = vim.defer_fn(function()
-    if unused_refs_states[bufnr] ~= state then
-      return
-    end
-
-    state.timer = nil
-    refresh_unused_reference_diagnostics_for_buffer(bufnr)
+    refresh_unused_reference_diagnostics_from_cache(
+      bufnr,
+      state,
+      seq,
+      initial_cache_key,
+      UNUSED_REFS_CACHE_TIMEOUT_MS
+    )
   end, UNUSED_REFS_REFRESH_DELAY_MS)
 end
 
@@ -371,7 +428,10 @@ intelephense.config = {
     active_clients[client.id] = bufnr
     if client:supports_method(vim.lsp.protocol.Methods.textDocument_codeLens, bufnr) then
       attach_unused_reference_updates_once(bufnr)
-      refresh_unused_reference_diagnostics(client, bufnr)
+      local state = unused_refs_states[bufnr]
+      if state then
+        schedule_unused_reference_refresh(bufnr, state)
+      end
     end
     register_commands_once()
   end,

--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
@@ -51,6 +51,7 @@ local indexing_in_progress = false
 local active_clients = {}
 ---@type table<integer, dotfiles.IntelephenseUnusedRefsState>
 local unused_refs_states = {}
+local unused_refs_augroup = vim.api.nvim_create_augroup('dotfiles-intelephense-unused-refs', { clear = true })
 
 local function get_client()
   return vim.lsp.get_clients({ name = 'intelephense' })[1]
@@ -332,12 +333,67 @@ local function codelens_cache_key(lenses)
 end
 
 ---@param client_id integer
+---@return table<integer, true>?
+local function prune_active_client_buffers(client_id)
+  local bufnrs = active_clients[client_id]
+  if not bufnrs then
+    return nil
+  end
+
+  for bufnr in pairs(bufnrs) do
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+      bufnrs[bufnr] = nil
+    end
+  end
+
+  if next(bufnrs) == nil then
+    active_clients[client_id] = nil
+    return nil
+  end
+
+  active_clients[client_id] = bufnrs
+  return bufnrs
+end
+
+---@param client_id integer
 ---@param bufnr integer
 local function track_active_client_buffer(client_id, bufnr)
-  local bufnrs = active_clients[client_id] or {}
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  local bufnrs = prune_active_client_buffers(client_id) or {}
   bufnrs[bufnr] = true
   active_clients[client_id] = bufnrs
 end
+
+---@param client_id integer
+---@param bufnr integer
+local function untrack_active_client_buffer(client_id, bufnr)
+  local bufnrs = prune_active_client_buffers(client_id)
+  if not bufnrs then
+    return
+  end
+
+  bufnrs[bufnr] = nil
+  if next(bufnrs) == nil then
+    active_clients[client_id] = nil
+    return
+  end
+
+  active_clients[client_id] = bufnrs
+end
+
+---@param bufnr integer
+local function untrack_buffer_from_all_active_clients(bufnr)
+  for client_id in pairs(active_clients) do
+    untrack_active_client_buffer(client_id, bufnr)
+  end
+end
+
+---@param bufnr integer
+---@return boolean
+local has_active_client_in_buffer
 
 ---@param bufnr integer
 ---@param client vim.lsp.Client
@@ -366,7 +422,7 @@ local function resolve_unused_reference_lenses(bufnr, client, state, seq, lenses
   for index, lens in ipairs(resolved_lenses) do
     if not lens.command then
       pending = pending + 1
-      client:request(Methods.codeLens_resolve, lens, function(err, resolved_lens)
+      local ok = client:request(Methods.codeLens_resolve, lens, function(err, resolved_lens)
         if finished or not is_unused_reference_refresh_current(bufnr, state, seq) then
           return
         end
@@ -380,6 +436,13 @@ local function resolve_unused_reference_lenses(bufnr, client, state, seq, lenses
           finish()
         end
       end, bufnr)
+
+      if not ok then
+        pending = pending - 1
+        if pending == 0 then
+          finish()
+        end
+      end
     end
   end
 
@@ -498,6 +561,32 @@ local function attach_unused_reference_updates_once(bufnr)
 
   local state = {}
   unused_refs_states[bufnr] = state
+  pcall(vim.api.nvim_clear_autocmds, { group = unused_refs_augroup, buffer = bufnr })
+  vim.api.nvim_create_autocmd('LspDetach', {
+    group = unused_refs_augroup,
+    buffer = bufnr,
+    callback = function(args)
+      local client_id = args.data and args.data.client_id
+      if not client_id then
+        return
+      end
+
+      local client = vim.lsp.get_client_by_id(client_id)
+      if client and client.name ~= 'intelephense' then
+        return
+      end
+
+      untrack_active_client_buffer(client_id, args.buf)
+      if not has_active_client_in_buffer(args.buf) then
+        clear_unused_reference_state(args.buf)
+        clear_unused_reference_diagnostics(args.buf)
+      end
+
+      if next(active_clients) == nil then
+        unregister_commands()
+      end
+    end,
+  })
   local attached = vim.api.nvim_buf_attach(bufnr, false, {
     on_lines = function(_, buf)
       if unused_refs_states[buf] ~= state then
@@ -514,6 +603,8 @@ local function attach_unused_reference_updates_once(bufnr)
       schedule_unused_reference_refresh(buf, state)
     end,
     on_detach = function(_, buf)
+      untrack_buffer_from_all_active_clients(buf)
+      pcall(vim.api.nvim_clear_autocmds, { group = unused_refs_augroup, buffer = buf })
       clear_unused_reference_state(buf, state)
     end,
   })
@@ -523,9 +614,15 @@ local function attach_unused_reference_updates_once(bufnr)
   end
 end
 
-local function has_active_client_in_buffer(bufnr)
-  for _, active_bufnrs in pairs(active_clients) do
-    if active_bufnrs[bufnr] then
+has_active_client_in_buffer = function(bufnr)
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    untrack_buffer_from_all_active_clients(bufnr)
+    return false
+  end
+
+  for client_id in pairs(active_clients) do
+    local active_bufnrs = prune_active_client_buffers(client_id)
+    if active_bufnrs and active_bufnrs[bufnr] then
       return true
     end
   end
@@ -568,7 +665,7 @@ intelephense.config = {
 
   -- LSP on_exit may run in a fast event; schedule all editor-state cleanup.
   on_exit = vim.schedule_wrap(function(_, _, client_id)
-    local bufnrs = active_clients[client_id] or {}
+    local bufnrs = prune_active_client_buffers(client_id) or {}
     active_clients[client_id] = nil
 
     for bufnr in pairs(bufnrs) do

--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
@@ -392,6 +392,21 @@ end
 ---@param client vim.lsp.Client
 ---@param state dotfiles.IntelephenseUnusedRefsState
 ---@param seq integer
+---@param lenses lsp.CodeLens[]?
+local function apply_unused_reference_diagnostics(bufnr, client, state, seq, lenses)
+  resolve_unused_reference_lenses(bufnr, client, state, seq, lenses, function(resolved_lenses)
+    if not is_unused_reference_refresh_current(bufnr, state, seq) then
+      return
+    end
+
+    set_unused_reference_diagnostics(bufnr, client, resolved_lenses)
+  end)
+end
+
+---@param bufnr integer
+---@param client vim.lsp.Client
+---@param state dotfiles.IntelephenseUnusedRefsState
+---@param seq integer
 local function request_unused_reference_diagnostics(bufnr, client, state, seq)
   local params = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
   client:request(Methods.textDocument_codeLens, params, function(err, lenses)
@@ -405,13 +420,7 @@ local function request_unused_reference_diagnostics(bufnr, client, state, seq)
       return
     end
 
-    resolve_unused_reference_lenses(bufnr, client, state, seq, lenses, function(resolved_lenses)
-      if not is_unused_reference_refresh_current(bufnr, state, seq) then
-        return
-      end
-
-      set_unused_reference_diagnostics(bufnr, client, resolved_lenses)
-    end)
+    apply_unused_reference_diagnostics(bufnr, client, state, seq, lenses)
   end, bufnr)
 end
 
@@ -436,7 +445,7 @@ local function refresh_unused_reference_diagnostics_from_cache(bufnr, state, seq
   local cache_key = codelens_cache_key(lenses)
   if cache_key ~= initial_cache_key then
     state.timer = nil
-    set_unused_reference_diagnostics(bufnr, client, lenses)
+    apply_unused_reference_diagnostics(bufnr, client, state, seq, lenses)
     return
   end
 

--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
@@ -67,7 +67,10 @@ local function register_commands_once()
     end
 
     local root_dir = client.config.root_dir
-    vim.lsp.stop_client(client.id)
+    -- Prefer a graceful shutdown here: forcing termination while the server is
+    -- writing cache/index files risks corruption. The explicit false keeps this
+    -- behavior independent of any future client exit_timeout setting.
+    client:stop(false)
 
     local stopped = vim.wait(STOP_TIMEOUT, function()
       return client:is_stopped()
@@ -294,7 +297,8 @@ intelephense.config = {
     register_commands_once()
   end,
 
-  on_exit = function(_, _, client_id)
+  -- LSP on_exit may run in a fast event; schedule all editor-state cleanup.
+  on_exit = vim.schedule_wrap(function(_, _, client_id)
     local bufnr = active_clients[client_id]
     active_clients[client_id] = nil
 
@@ -302,18 +306,14 @@ intelephense.config = {
       pcall(vim.api.nvim_clear_autocmds, { group = unused_refs_augroup, buffer = bufnr })
       if vim.api.nvim_buf_is_valid(bufnr) then
         vim.b[bufnr].intelephense_unused_refs_autocmd = nil
+        vim.diagnostic.set(unused_refs_ns, bufnr, {})
       end
-      vim.schedule(function()
-        if vim.api.nvim_buf_is_valid(bufnr) then
-          vim.diagnostic.set(unused_refs_ns, bufnr, {})
-        end
-      end)
     end
 
     if next(active_clients) == nil then
       unregister_commands()
     end
-  end,
+  end),
 }
 
 M.lspconfigs = { intelephense }

--- a/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/lsp/php.lua
@@ -343,6 +343,55 @@ end
 ---@param client vim.lsp.Client
 ---@param state dotfiles.IntelephenseUnusedRefsState
 ---@param seq integer
+---@param lenses lsp.CodeLens[]?
+---@param on_done fun(resolved_lenses: lsp.CodeLens[])
+local function resolve_unused_reference_lenses(bufnr, client, state, seq, lenses, on_done)
+  local resolved_lenses = vim.deepcopy(lenses or {})
+  if not client:supports_method(Methods.codeLens_resolve, bufnr) then
+    on_done(resolved_lenses)
+    return
+  end
+
+  local pending = 0
+  local finished = false
+  local function finish()
+    if finished then
+      return
+    end
+
+    finished = true
+    on_done(resolved_lenses)
+  end
+
+  for index, lens in ipairs(resolved_lenses) do
+    if not lens.command then
+      pending = pending + 1
+      client:request(Methods.codeLens_resolve, lens, function(err, resolved_lens)
+        if finished or not is_unused_reference_refresh_current(bufnr, state, seq) then
+          return
+        end
+
+        pending = pending - 1
+        if not err and resolved_lens then
+          resolved_lenses[index] = resolved_lens
+        end
+
+        if pending == 0 then
+          finish()
+        end
+      end, bufnr)
+    end
+  end
+
+  if pending == 0 then
+    finish()
+  end
+end
+
+---@param bufnr integer
+---@param client vim.lsp.Client
+---@param state dotfiles.IntelephenseUnusedRefsState
+---@param seq integer
 local function request_unused_reference_diagnostics(bufnr, client, state, seq)
   local params = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
   client:request(Methods.textDocument_codeLens, params, function(err, lenses)
@@ -356,7 +405,13 @@ local function request_unused_reference_diagnostics(bufnr, client, state, seq)
       return
     end
 
-    set_unused_reference_diagnostics(bufnr, client, lenses)
+    resolve_unused_reference_lenses(bufnr, client, state, seq, lenses, function(resolved_lenses)
+      if not is_unused_reference_refresh_current(bufnr, state, seq) then
+        return
+      end
+
+      set_unused_reference_diagnostics(bufnr, client, resolved_lenses)
+    end)
   end, bufnr)
 end
 

--- a/home/.chezmoitemplates/nvim/lua/configs/plugins/nvim-lspconfig.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/plugins/nvim-lspconfig.lua
@@ -98,7 +98,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
       codelens_clients[client.id] = true
       vim.b[event.buf].lsp_codelens_clients = codelens_clients
 
-      vim.lsp.codelens.refresh({ bufnr = event.buf })
+      vim.lsp.codelens.enable(true, { bufnr = event.buf })
 
       -- Only create autocmds once per buffer (first codelens-capable client)
       if vim.tbl_count(codelens_clients) == 1 then
@@ -107,7 +107,7 @@ vim.api.nvim_create_autocmd('LspAttach', {
           buffer = event.buf,
           group = codelens_augroup,
           callback = function()
-            vim.lsp.codelens.refresh({ bufnr = event.buf })
+            vim.lsp.codelens.enable(true, { bufnr = event.buf })
           end,
         })
       end
@@ -141,7 +141,7 @@ vim.api.nvim_create_autocmd('LspDetach', {
       codelens_clients[client_id] = nil
       if next(codelens_clients) == nil then
         pcall(vim.api.nvim_clear_autocmds, { group = 'lsp-codelens', buffer = bufnr })
-        vim.lsp.codelens.clear(nil, bufnr)
+        vim.lsp.codelens.enable(false, { bufnr = bufnr, client_id = client_id })
         vim.b[bufnr].lsp_codelens_clients = nil
       else
         vim.b[bufnr].lsp_codelens_clients = codelens_clients
@@ -167,8 +167,11 @@ vim.diagnostic.config({
   virtual_lines = {
     current_line = true,
   },
-  -- TODO: Neovim 0.12+ jump.on_jump (see https://github.com/neovim/neovim/issues/33154)
-  jump = { float = true },
+  jump = {
+    on_jump = function(_, bufnr)
+      vim.diagnostic.open_float({ bufnr = bufnr, scope = 'cursor', focus = false })
+    end,
+  },
 })
 
 -- Diagnostic keymaps

--- a/home/.chezmoitemplates/nvim/lua/configs/plugins/nvim-lspconfig.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/plugins/nvim-lspconfig.lua
@@ -1,5 +1,3 @@
-local lsp_codelens = require('utils.lsp_codelens')
-
 -- LSP buffer-local setup (keymaps, highlights, inlay hints)
 vim.api.nvim_create_autocmd('LspAttach', {
   group = vim.api.nvim_create_augroup('kickstart-lsp-attach', { clear = true }),
@@ -87,15 +85,6 @@ vim.api.nvim_create_autocmd('LspAttach', {
         vim.lsp.inlay_hint.enable(not vim.lsp.inlay_hint.is_enabled({ bufnr = event.buf }))
       end, '[T]oggle Inlay [H]ints')
     end
-
-    -- CodeLens (if supported)
-    if
-      client
-      and client_supports_method(client, vim.lsp.protocol.Methods.textDocument_codeLens, event.buf)
-      and not lsp_codelens.is_context_active(event.buf)
-    then
-      vim.lsp.codelens.enable(true, { bufnr = event.buf })
-    end
   end,
 })
 
@@ -120,6 +109,9 @@ vim.api.nvim_create_autocmd('LspDetach', {
     end
   end,
 })
+
+-- Enable built-in CodeLens globally; explicit git contexts opt out per-buffer.
+vim.lsp.codelens.enable(true)
 
 vim.diagnostic.config({
   update_in_insert = false,

--- a/home/.chezmoitemplates/nvim/lua/configs/plugins/nvim-lspconfig.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/plugins/nvim-lspconfig.lua
@@ -92,8 +92,9 @@ vim.api.nvim_create_autocmd('LspAttach', {
     if
       client
       and client_supports_method(client, vim.lsp.protocol.Methods.textDocument_codeLens, event.buf)
+      and not lsp_codelens.is_context_active(event.buf)
     then
-      lsp_codelens.attach(client, event.buf)
+      vim.lsp.codelens.enable(true, { bufnr = event.buf })
     end
   end,
 })
@@ -117,8 +118,6 @@ vim.api.nvim_create_autocmd('LspDetach', {
         vim.b[bufnr].lsp_highlight_clients = highlight_clients
       end
     end
-
-    lsp_codelens.detach(bufnr, client_id)
   end,
 })
 

--- a/home/.chezmoitemplates/nvim/lua/configs/plugins/nvim-lspconfig.lua
+++ b/home/.chezmoitemplates/nvim/lua/configs/plugins/nvim-lspconfig.lua
@@ -1,3 +1,5 @@
+local lsp_codelens = require('utils.lsp_codelens')
+
 -- LSP buffer-local setup (keymaps, highlights, inlay hints)
 vim.api.nvim_create_autocmd('LspAttach', {
   group = vim.api.nvim_create_augroup('kickstart-lsp-attach', { clear = true }),
@@ -87,30 +89,11 @@ vim.api.nvim_create_autocmd('LspAttach', {
     end
 
     -- CodeLens (if supported)
-    -- TODO: When PR #36469 merges, add { display = { virt_lines = true } } for above-line display
-    -- Track: https://github.com/neovim/neovim/pull/36469
     if
       client
       and client_supports_method(client, vim.lsp.protocol.Methods.textDocument_codeLens, event.buf)
     then
-      -- Track this client as supporting codelens (vim.b returns copies, must reassign)
-      local codelens_clients = vim.b[event.buf].lsp_codelens_clients or {}
-      codelens_clients[client.id] = true
-      vim.b[event.buf].lsp_codelens_clients = codelens_clients
-
-      vim.lsp.codelens.enable(true, { bufnr = event.buf })
-
-      -- Only create autocmds once per buffer (first codelens-capable client)
-      if vim.tbl_count(codelens_clients) == 1 then
-        local codelens_augroup = vim.api.nvim_create_augroup('lsp-codelens', { clear = false })
-        vim.api.nvim_create_autocmd({ 'InsertLeave', 'BufWritePost' }, {
-          buffer = event.buf,
-          group = codelens_augroup,
-          callback = function()
-            vim.lsp.codelens.enable(true, { bufnr = event.buf })
-          end,
-        })
-      end
+      lsp_codelens.attach(client, event.buf)
     end
   end,
 })
@@ -135,18 +118,7 @@ vim.api.nvim_create_autocmd('LspDetach', {
       end
     end
 
-    -- Remove from codelens clients and cleanup if none remain (vim.b returns copies, must reassign)
-    local codelens_clients = vim.b[bufnr].lsp_codelens_clients
-    if codelens_clients and codelens_clients[client_id] then
-      codelens_clients[client_id] = nil
-      if next(codelens_clients) == nil then
-        pcall(vim.api.nvim_clear_autocmds, { group = 'lsp-codelens', buffer = bufnr })
-        vim.lsp.codelens.enable(false, { bufnr = bufnr, client_id = client_id })
-        vim.b[bufnr].lsp_codelens_clients = nil
-      else
-        vim.b[bufnr].lsp_codelens_clients = codelens_clients
-      end
-    end
+    lsp_codelens.detach(bufnr, client_id)
   end,
 })
 

--- a/home/.chezmoitemplates/nvim/lua/plugins/git.lua
+++ b/home/.chezmoitemplates/nvim/lua/plugins/git.lua
@@ -40,6 +40,11 @@ return {
       ---@field file DiffviewMainFileLike
       ---@class DiffviewLayoutLike
       ---@field get_main_win fun(self: DiffviewLayoutLike): DiffviewMainWinLike
+      ---@class DiffviewEmitterLike
+      ---@field on fun(self: DiffviewEmitterLike, event: string, callback: fun(...))
+      ---@class DiffviewViewLike
+      ---@field cur_layout? DiffviewLayoutLike
+      ---@field emitter? DiffviewEmitterLike
 
       -- Diffview virtual buffers may contain raw CP932 bytes from git.
       -- Convert only when the current main diff buffer is SJIS/CP932.
@@ -88,6 +93,8 @@ return {
 
       ---@type integer|nil
       local diffview_codelens_bufnr = nil
+      ---@type table<DiffviewViewLike, true>
+      local diffview_codelens_views = setmetatable({}, { __mode = 'k' })
 
       local function clear_diffview_codelens()
         if not diffview_codelens_bufnr then
@@ -110,6 +117,24 @@ return {
           lsp_codelens.set_context(main_buf, 'diffview', 'eol')
           diffview_codelens_bufnr = main_buf
         end
+      end
+
+      ---@param view? DiffviewViewLike
+      local function attach_diffview_codelens_listener(view)
+        if type(view) ~= 'table' or diffview_codelens_views[view] then
+          return
+        end
+
+        local ok = pcall(function()
+          view.emitter:on('file_open_post', function()
+            sync_diffview_codelens(view)
+          end)
+        end)
+        if not ok then
+          return
+        end
+
+        diffview_codelens_views[view] = true
       end
 
       -- Diffview hooks also run for local file buffers; filter to virtual diffview buffers.
@@ -263,9 +288,13 @@ return {
       diffview.setup({
         hooks = {
           view_opened = function(view)
+            attach_diffview_codelens_listener(view)
             sync_diffview_codelens(view)
           end,
-          view_closed = function()
+          view_closed = function(view)
+            if type(view) == 'table' then
+              diffview_codelens_views[view] = nil
+            end
             clear_diffview_codelens()
           end,
           view_enter = function(view)
@@ -275,8 +304,6 @@ return {
             clear_diffview_codelens()
           end,
           diff_buf_read = function(bufnr, _)
-            sync_diffview_codelens()
-
             -- diff_buf_read also fires for local file buffers; only process
             -- Diffview virtual buffers here.
             if not is_diffview_buf(bufnr) then

--- a/home/.chezmoitemplates/nvim/lua/plugins/git.lua
+++ b/home/.chezmoitemplates/nvim/lua/plugins/git.lua
@@ -1,6 +1,7 @@
 -- One-shot target line used by blame -> Diffview handoff.
 ---@type integer|nil
 local pending_blame_diffview_lnum = nil
+local lsp_codelens = require('utils.lsp_codelens')
 -- Monotonic id for blame->Diffview jump requests.
 -- Deferred cleanup only clears state when its captured id is still current.
 ---@type integer
@@ -60,6 +61,55 @@ return {
 
         local view = diffview_lib.get_current_view()
         return view and view.cur_layout or nil
+      end
+
+      ---@param view? { cur_layout?: DiffviewLayoutLike }
+      ---@return integer|nil
+      local function current_main_bufnr(view)
+        local layout = view and view.cur_layout or current_layout()
+        if not layout then
+          return nil
+        end
+
+        local ok_main, main_win = pcall(function()
+          return layout:get_main_win()
+        end)
+        if not ok_main or not main_win then
+          return nil
+        end
+
+        local main_buf = main_win.file and main_win.file.bufnr
+        if not main_buf or not vim.api.nvim_buf_is_valid(main_buf) then
+          return nil
+        end
+
+        return main_buf
+      end
+
+      ---@type integer|nil
+      local diffview_codelens_bufnr = nil
+
+      local function clear_diffview_codelens()
+        if not diffview_codelens_bufnr then
+          return
+        end
+
+        lsp_codelens.clear_context(diffview_codelens_bufnr, 'diffview')
+        diffview_codelens_bufnr = nil
+      end
+
+      ---@param view? { cur_layout?: DiffviewLayoutLike }
+      local function sync_diffview_codelens(view)
+        local main_buf = current_main_bufnr(view)
+        if diffview_codelens_bufnr == main_buf then
+          return
+        end
+
+        clear_diffview_codelens()
+        if main_buf then
+          lsp_codelens.set_context(main_buf, 'diffview', 'eol')
+          diffview_codelens_bufnr = main_buf
+        end
       end
 
       -- Diffview hooks also run for local file buffers; filter to virtual diffview buffers.
@@ -212,7 +262,21 @@ return {
 
       diffview.setup({
         hooks = {
+          view_opened = function(view)
+            sync_diffview_codelens(view)
+          end,
+          view_closed = function()
+            clear_diffview_codelens()
+          end,
+          view_enter = function(view)
+            sync_diffview_codelens(view)
+          end,
+          view_leave = function()
+            clear_diffview_codelens()
+          end,
           diff_buf_read = function(bufnr, _)
+            sync_diffview_codelens()
+
             -- diff_buf_read also fires for local file buffers; only process
             -- Diffview virtual buffers here.
             if not is_diffview_buf(bufnr) then
@@ -426,6 +490,9 @@ return {
           return
         end
 
+        if source_buf and vim.api.nvim_buf_is_valid(source_buf) then
+          lsp_codelens.clear_context(source_buf, 'gitsigns_blame')
+        end
         in_source_win(restore_plugins)
         blame_count = 0
         source_win = nil
@@ -441,6 +508,9 @@ return {
             -- Capture source window and buffer (alternate window when blame split is created)
             source_win = vim.fn.win_getid(vim.fn.winnr('#'))
             source_buf = vim.api.nvim_win_get_buf(source_win)
+            if vim.api.nvim_buf_is_valid(source_buf) then
+              lsp_codelens.set_context(source_buf, 'gitsigns_blame', 'eol')
+            end
             in_source_win(function()
               for _, p in ipairs(loaded) do
                 p.was_active = p.is_active(p.module)

--- a/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
+++ b/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
@@ -397,13 +397,24 @@ function M.is_active(bufnr)
   return state ~= nil and has_contexts(state)
 end
 
+---@param bufnr? integer
+---@return integer
+local function resolve_bufnr(bufnr)
+  if bufnr == nil or bufnr == 0 then
+    return api.nvim_get_current_buf()
+  end
+
+  vim.validate('bufnr', bufnr, 'number')
+  return bufnr
+end
+
 ---@param filter? vim.lsp.codelens.get.Filter
 ---@return vim.lsp.codelens.get.Result[]
 function M.get(filter)
   vim.validate('filter', filter, 'table', true)
   filter = filter or {}
 
-  local bufnr = vim._resolve_bufnr(filter.bufnr)
+  local bufnr = resolve_bufnr(filter.bufnr)
   local state = get_state(bufnr)
   if not state then
     return {}

--- a/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
+++ b/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
@@ -359,13 +359,6 @@ function M.refresh(bufnr)
 end
 
 ---@param bufnr integer
----@return boolean
-function M.is_context_active(bufnr)
-  local state = get_state(bufnr)
-  return state ~= nil and has_contexts(state)
-end
-
----@param bufnr integer
 ---@param key string
 ---@param placement 'eol'
 function M.set_context(bufnr, key, placement)

--- a/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
+++ b/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
@@ -271,6 +271,8 @@ local function refresh_now(bufnr)
     return
   end
 
+  -- Mirror Neovim's built-in CodeLens request/resolve lifecycle, but keep
+  -- rendering local so git-driven contexts can place titles at end-of-line.
   reset_timer(state)
   state.refresh_seq = state.refresh_seq + 1
   state.client_rows = {}
@@ -371,6 +373,8 @@ function M.set_context(bufnr, key, placement)
     return
   end
 
+  -- The first active context takes ownership from the built-in provider.
+  -- Additional contexts share the same cached state and render pass.
   local was_inactive = not has_contexts(state)
   state.contexts[key] = placement
 

--- a/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
+++ b/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
@@ -12,6 +12,7 @@ local refresh_delay_ms = 200
 ---@field client_rows table<integer, table<integer, lsp.CodeLens[]>>
 ---@field refresh_seq integer
 ---@field timer? uv.uv_timer_t
+---@field render_scheduled? boolean
 
 ---@type table<integer, dotfiles.LspCodeLensState>
 local states = {}
@@ -160,13 +161,36 @@ end
 
 ---@param bufnr integer
 ---@param state dotfiles.LspCodeLensState
-local function render(bufnr, state)
+local render
+
+---@param bufnr integer
+---@param state dotfiles.LspCodeLensState
+local function schedule_render(bufnr, state)
+  if state.render_scheduled then
+    return
+  end
+
+  state.render_scheduled = true
+  vim.schedule(function()
+    if states[bufnr] ~= state then
+      return
+    end
+
+    state.render_scheduled = nil
+    render(bufnr, state)
+  end)
+end
+
+---@param bufnr integer
+---@param state dotfiles.LspCodeLensState
+render = function(bufnr, state)
   if not api.nvim_buf_is_valid(bufnr) then
     return
   end
 
   clear_extmarks(bufnr)
 
+  local line_count = api.nvim_buf_line_count(bufnr)
   local merged_rows = {}
   for client_id, rows in pairs(state.client_rows) do
     local client = vim.lsp.get_client_by_id(client_id)
@@ -188,6 +212,10 @@ local function render(bufnr, state)
   end
 
   for line, items in pairs(merged_rows) do
+    if type(line) ~= 'number' or line < 0 or line >= line_count then
+      goto continue
+    end
+
     table.sort(items, function(a, b)
       if a.col == b.col then
         return a.title < b.title
@@ -213,6 +241,8 @@ local function render(bufnr, state)
         hl_mode = 'combine',
       })
     end
+
+    ::continue::
   end
 end
 
@@ -257,7 +287,7 @@ local function resolve_lens(client, bufnr, state, seq, tick, unresolved_lens)
     for index, lens in ipairs(row_lenses) do
       if lens == unresolved_lens then
         row_lenses[index] = resolved_lens
-        render(bufnr, state)
+        schedule_render(bufnr, state)
         return
       end
     end
@@ -292,13 +322,13 @@ local function refresh_now(bufnr)
 
         if err then
           state.client_rows[client.id] = {}
-          render(bufnr, state)
+          schedule_render(bufnr, state)
           return
         end
 
         local rows = group_lenses(result)
         state.client_rows[client.id] = rows
-        render(bufnr, state)
+        schedule_render(bufnr, state)
 
         if client:supports_method(Methods.codeLens_resolve, bufnr) then
           for _, row_lenses in pairs(rows) do
@@ -358,6 +388,61 @@ end
 
 function M.refresh(bufnr)
   refresh_now(bufnr)
+end
+
+---@param bufnr integer
+---@return boolean
+function M.is_active(bufnr)
+  local state = get_state(bufnr)
+  return state ~= nil and has_contexts(state)
+end
+
+---@param filter? vim.lsp.codelens.get.Filter
+---@return vim.lsp.codelens.get.Result[]
+function M.get(filter)
+  vim.validate('filter', filter, 'table', true)
+  filter = filter or {}
+
+  local bufnr = vim._resolve_bufnr(filter.bufnr)
+  local state = get_state(bufnr)
+  if not state then
+    return {}
+  end
+
+  local result = {}
+  for client_id, rows in pairs(state.client_rows) do
+    if not filter.client_id or filter.client_id == client_id then
+      for _, lenses in pairs(rows) do
+        for _, lens in ipairs(lenses) do
+          result[#result + 1] = {
+            client_id = client_id,
+            lens = lens,
+          }
+        end
+      end
+    end
+  end
+
+  table.sort(result, function(a, b)
+    if a.client_id ~= b.client_id then
+      return a.client_id < b.client_id
+    end
+
+    local a_start = a.lens.range.start
+    local b_start = b.lens.range.start
+    if a_start.line ~= b_start.line then
+      return a_start.line < b_start.line
+    end
+    if a_start.character ~= b_start.character then
+      return a_start.character < b_start.character
+    end
+
+    local a_title = a.lens.command and a.lens.command.title or ''
+    local b_title = b.lens.command and b.lens.command.title or ''
+    return a_title < b_title
+  end)
+
+  return result
 end
 
 ---@param bufnr integer

--- a/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
+++ b/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
@@ -1,0 +1,361 @@
+local api = vim.api
+local Methods = vim.lsp.protocol.Methods
+
+local M = {}
+
+local namespace = api.nvim_create_namespace('dotfiles.lsp.codelens')
+local augroup = api.nvim_create_augroup('dotfiles-lsp-codelens', { clear = false })
+local refresh_delay_ms = 200
+
+---@class dotfiles.LspCodeLensEntry
+---@field col integer
+---@field title string
+
+---@class dotfiles.LspCodeLensState
+---@field clients table<integer, true>
+---@field client_rows table<integer, table<integer, dotfiles.LspCodeLensEntry[]>>
+---@field refresh_seq integer
+---@field timer? uv.uv_timer_t
+
+---@type table<integer, dotfiles.LspCodeLensState>
+local states = {}
+
+---@param state dotfiles.LspCodeLensState
+local function reset_timer(state)
+  local timer = state.timer
+  if not timer then
+    return
+  end
+
+  state.timer = nil
+  if timer:is_closing() then
+    return
+  end
+
+  timer:stop()
+  timer:close()
+end
+
+---@param bufnr integer
+local function clear_extmarks(bufnr)
+  if api.nvim_buf_is_valid(bufnr) then
+    api.nvim_buf_clear_namespace(bufnr, namespace, 0, -1)
+  end
+end
+
+---@param bufnr integer
+---@return dotfiles.LspCodeLensState?
+local function get_state(bufnr)
+  local state = states[bufnr]
+  if not state then
+    return nil
+  end
+
+  if api.nvim_buf_is_valid(bufnr) then
+    return state
+  end
+
+  reset_timer(state)
+  states[bufnr] = nil
+  return nil
+end
+
+---@param bufnr integer
+---@return dotfiles.LspCodeLensState
+local function ensure_state(bufnr)
+  local state = get_state(bufnr)
+  if state then
+    return state
+  end
+
+  state = {
+    clients = {},
+    client_rows = {},
+    refresh_seq = 0,
+  }
+  states[bufnr] = state
+
+  api.nvim_create_autocmd('BufWipeout', {
+    buffer = bufnr,
+    group = augroup,
+    callback = function(args)
+      M.detach_all(args.buf)
+    end,
+  })
+
+  api.nvim_create_autocmd('InsertEnter', {
+    buffer = bufnr,
+    group = augroup,
+    callback = function(args)
+      M.clear(args.buf)
+    end,
+  })
+
+  api.nvim_create_autocmd('TextChanged', {
+    buffer = bufnr,
+    group = augroup,
+    callback = function(args)
+      M.clear(args.buf)
+      M.schedule_refresh(args.buf)
+    end,
+  })
+
+  api.nvim_create_autocmd('TextChangedI', {
+    buffer = bufnr,
+    group = augroup,
+    callback = function(args)
+      M.clear(args.buf)
+    end,
+  })
+
+  api.nvim_create_autocmd({ 'InsertLeave', 'BufWritePost' }, {
+    buffer = bufnr,
+    group = augroup,
+    callback = function(args)
+      M.refresh(args.buf)
+    end,
+  })
+
+  return state
+end
+
+---@param state dotfiles.LspCodeLensState
+---@param seq integer
+---@param tick integer
+---@return boolean
+local function is_refresh_current(bufnr, state, seq, tick)
+  return states[bufnr] == state
+    and state.refresh_seq == seq
+    and api.nvim_buf_is_valid(bufnr)
+    and api.nvim_buf_get_changedtick(bufnr) == tick
+end
+
+---@param rows table<integer, dotfiles.LspCodeLensEntry[]>
+---@param lens lsp.CodeLens?
+local function add_entry(rows, lens)
+  if not lens or not lens.command or type(lens.command.title) ~= 'string' then
+    return
+  end
+
+  local title = vim.trim(lens.command.title)
+  if title == '' then
+    return
+  end
+
+  local line = lens.range.start.line
+  local entries = rows[line] or {}
+  entries[#entries + 1] = {
+    col = lens.range.start.character,
+    title = title,
+  }
+  rows[line] = entries
+end
+
+---@param bufnr integer
+---@param client_rows table<integer, table<integer, dotfiles.LspCodeLensEntry[]>>
+local function render(bufnr, client_rows)
+  if not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  clear_extmarks(bufnr)
+
+  ---@type table<integer, dotfiles.LspCodeLensEntry[]>
+  local merged_rows = {}
+  for _, rows in pairs(client_rows) do
+    for line, entries in pairs(rows) do
+      local merged = merged_rows[line] or {}
+      vim.list_extend(merged, entries)
+      merged_rows[line] = merged
+    end
+  end
+
+  for line, entries in pairs(merged_rows) do
+    table.sort(entries, function(a, b)
+      if a.col == b.col then
+        return a.title < b.title
+      end
+
+      return a.col < b.col
+    end)
+
+    ---@type [string, string][]
+    local virt_text = { { '  ', 'LspCodeLensSeparator' } }
+    for index, entry in ipairs(entries) do
+      virt_text[#virt_text + 1] = { entry.title, 'LspCodeLens' }
+      if index < #entries then
+        virt_text[#virt_text + 1] = { ' | ', 'LspCodeLensSeparator' }
+      end
+    end
+
+    api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
+      virt_text = virt_text,
+      virt_text_pos = 'eol',
+      hl_mode = 'combine',
+    })
+  end
+end
+
+---@param client vim.lsp.Client
+---@param bufnr integer
+---@param state dotfiles.LspCodeLensState
+---@param seq integer
+---@param tick integer
+---@param lenses lsp.CodeLens[]?
+---@param done fun(rows: table<integer, dotfiles.LspCodeLensEntry[]>)
+local function resolve_rows(client, bufnr, state, seq, tick, lenses, done)
+  ---@type table<integer, dotfiles.LspCodeLensEntry[]>
+  local rows = {}
+  local pending = 1
+  local can_resolve = client:supports_method(Methods.codeLens_resolve, bufnr)
+
+  local function finish()
+    pending = pending - 1
+    if pending == 0 then
+      done(rows)
+    end
+  end
+
+  for _, lens in ipairs(lenses or {}) do
+    if lens.command then
+      add_entry(rows, lens)
+    elseif can_resolve then
+      pending = pending + 1
+      client:request(Methods.codeLens_resolve, lens, function(err, resolved_lens)
+        if not err and is_refresh_current(bufnr, state, seq, tick) then
+          add_entry(rows, resolved_lens)
+        end
+        finish()
+      end, bufnr)
+    end
+  end
+
+  finish()
+end
+
+---@param bufnr integer
+local function refresh_now(bufnr)
+  local state = get_state(bufnr)
+  if not state then
+    return
+  end
+
+  reset_timer(state)
+  state.refresh_seq = state.refresh_seq + 1
+  state.client_rows = {}
+
+  local seq = state.refresh_seq
+  local tick = api.nvim_buf_get_changedtick(bufnr)
+  local params = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
+  local requested = false
+
+  for client_id in pairs(state.clients) do
+    local client = vim.lsp.get_client_by_id(client_id)
+    if client and client:supports_method(Methods.textDocument_codeLens, bufnr) then
+      requested = true
+      client:request(Methods.textDocument_codeLens, params, function(err, result)
+        if not is_refresh_current(bufnr, state, seq, tick) then
+          return
+        end
+
+        if err then
+          state.client_rows[client_id] = {}
+          render(bufnr, state.client_rows)
+          return
+        end
+
+        resolve_rows(client, bufnr, state, seq, tick, result, function(rows)
+          if not is_refresh_current(bufnr, state, seq, tick) then
+            return
+          end
+
+          state.client_rows[client_id] = rows
+          render(bufnr, state.client_rows)
+        end)
+      end, bufnr)
+    end
+  end
+
+  if not requested then
+    clear_extmarks(bufnr)
+  end
+end
+
+---@param bufnr integer
+function M.clear(bufnr)
+  local state = get_state(bufnr)
+  if not state then
+    return
+  end
+
+  reset_timer(state)
+  state.refresh_seq = state.refresh_seq + 1
+  state.client_rows = {}
+  clear_extmarks(bufnr)
+end
+
+---@param bufnr integer
+function M.schedule_refresh(bufnr)
+  local state = get_state(bufnr)
+  if not state then
+    return
+  end
+
+  reset_timer(state)
+  state.timer = vim.defer_fn(function()
+    refresh_now(bufnr)
+  end, refresh_delay_ms)
+end
+
+---@param bufnr integer
+function M.refresh(bufnr)
+  refresh_now(bufnr)
+end
+
+---@param client vim.lsp.Client
+---@param bufnr integer
+function M.attach(client, bufnr)
+  if not client or not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  local state = ensure_state(bufnr)
+  state.clients[client.id] = true
+  refresh_now(bufnr)
+end
+
+---@param bufnr integer
+---@param client_id integer
+function M.detach(bufnr, client_id)
+  local state = get_state(bufnr)
+  if not state or not state.clients[client_id] then
+    return
+  end
+
+  state.clients[client_id] = nil
+  state.client_rows[client_id] = nil
+
+  if next(state.clients) == nil then
+    M.detach_all(bufnr)
+    return
+  end
+
+  M.clear(bufnr)
+  refresh_now(bufnr)
+end
+
+---@param bufnr integer
+function M.detach_all(bufnr)
+  local state = get_state(bufnr)
+  if not state then
+    clear_extmarks(bufnr)
+    return
+  end
+
+  reset_timer(state)
+  states[bufnr] = nil
+  clear_extmarks(bufnr)
+  pcall(api.nvim_clear_autocmds, { group = augroup, buffer = bufnr })
+end
+
+return M

--- a/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
+++ b/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
@@ -6,23 +6,10 @@ local M = {}
 local namespace = api.nvim_create_namespace('dotfiles.lsp.codelens')
 local augroup = api.nvim_create_augroup('dotfiles-lsp-codelens', { clear = false })
 local refresh_delay_ms = 200
-local default_placement = 'above'
-
-local context_priority = {
-  gitsigns_blame = 20,
-  diffview = 10,
-}
-
----@alias dotfiles.LspCodeLensPlacement 'above'|'eol'
-
----@class dotfiles.LspCodeLensEntry
----@field col integer
----@field title string
 
 ---@class dotfiles.LspCodeLensState
----@field clients table<integer, true>
----@field client_rows table<integer, table<integer, dotfiles.LspCodeLensEntry[]>>
----@field contexts table<string, dotfiles.LspCodeLensPlacement>
+---@field contexts table<string, 'eol'>
+---@field client_rows table<integer, table<integer, lsp.CodeLens[]>>
 ---@field refresh_seq integer
 ---@field timer? uv.uv_timer_t
 
@@ -69,6 +56,36 @@ local function get_state(bufnr)
   return nil
 end
 
+---@param lens lsp.CodeLens
+---@return string?
+local function lens_title(lens)
+  if not lens.command or type(lens.command.title) ~= 'string' then
+    return nil
+  end
+
+  local title = vim.trim(lens.command.title)
+  return title ~= '' and title or nil
+end
+
+---@param bufnr integer
+---@param lens lsp.CodeLens
+---@param client vim.lsp.Client
+---@return integer
+local function lens_col(bufnr, lens, client)
+  local ok, range = pcall(vim.range.lsp, bufnr, lens.range, client.offset_encoding)
+  if ok and range and type(range.start_col) == 'number' then
+    return range.start_col
+  end
+
+  return lens.range.start.character
+end
+
+---@param state dotfiles.LspCodeLensState
+---@return boolean
+local function has_contexts(state)
+  return next(state.contexts) ~= nil
+end
+
 ---@param bufnr integer
 ---@return dotfiles.LspCodeLensState
 local function ensure_state(bufnr)
@@ -78,9 +95,8 @@ local function ensure_state(bufnr)
   end
 
   state = {
-    clients = {},
-    client_rows = {},
     contexts = {},
+    client_rows = {},
     refresh_seq = 0,
   }
   states[bufnr] = state
@@ -129,79 +145,17 @@ local function ensure_state(bufnr)
   return state
 end
 
----@param state dotfiles.LspCodeLensState
----@return dotfiles.LspCodeLensPlacement
-local function get_placement(state)
-  local best_priority = -1
-  local placement = default_placement
-
-  for key, override in pairs(state.contexts) do
-    local priority = context_priority[key] or 0
-    if override and priority > best_priority then
-      best_priority = priority
-      placement = override
-    end
-  end
-
-  return placement
-end
-
+---@param bufnr integer
 ---@param state dotfiles.LspCodeLensState
 ---@param seq integer
 ---@param tick integer
 ---@return boolean
 local function is_refresh_current(bufnr, state, seq, tick)
   return states[bufnr] == state
+    and has_contexts(state)
     and state.refresh_seq == seq
     and api.nvim_buf_is_valid(bufnr)
     and api.nvim_buf_get_changedtick(bufnr) == tick
-end
-
----@param rows table<integer, dotfiles.LspCodeLensEntry[]>
----@param lens lsp.CodeLens?
-local function add_entry(rows, lens)
-  if not lens or not lens.command or type(lens.command.title) ~= 'string' then
-    return
-  end
-
-  local title = vim.trim(lens.command.title)
-  if title == '' then
-    return
-  end
-
-  local line = lens.range.start.line
-  local entries = rows[line] or {}
-  entries[#entries + 1] = {
-    col = lens.range.start.character,
-    title = title,
-  }
-  rows[line] = entries
-end
-
----@param entries dotfiles.LspCodeLensEntry[]
----@param placement dotfiles.LspCodeLensPlacement
----@return [string, string][]
-local function build_chunks(entries, placement)
-  ---@type [string, string][]
-  local virt_text = {}
-
-  if placement == 'above' then
-    local indent = math.max(entries[1].col, 0)
-    if indent > 0 then
-      virt_text[#virt_text + 1] = { string.rep(' ', indent), 'LspCodeLensSeparator' }
-    end
-  else
-    virt_text[#virt_text + 1] = { '  ', 'LspCodeLensSeparator' }
-  end
-
-  for index, entry in ipairs(entries) do
-    virt_text[#virt_text + 1] = { entry.title, 'LspCodeLens' }
-    if index < #entries then
-      virt_text[#virt_text + 1] = { ' | ', 'LspCodeLensSeparator' }
-    end
-  end
-
-  return virt_text
 end
 
 ---@param bufnr integer
@@ -213,19 +167,28 @@ local function render(bufnr, state)
 
   clear_extmarks(bufnr)
 
-  ---@type table<integer, dotfiles.LspCodeLensEntry[]>
   local merged_rows = {}
-  for _, rows in pairs(state.client_rows) do
-    for line, entries in pairs(rows) do
-      local merged = merged_rows[line] or {}
-      vim.list_extend(merged, entries)
-      merged_rows[line] = merged
+  for client_id, rows in pairs(state.client_rows) do
+    local client = vim.lsp.get_client_by_id(client_id)
+    if client then
+      for line, lenses in pairs(rows) do
+        local items = merged_rows[line] or {}
+        for _, lens in ipairs(lenses) do
+          local title = lens_title(lens)
+          if title then
+            items[#items + 1] = {
+              col = lens_col(bufnr, lens, client),
+              title = title,
+            }
+          end
+        end
+        merged_rows[line] = items
+      end
     end
   end
 
-  local placement = get_placement(state)
-  for line, entries in pairs(merged_rows) do
-    table.sort(entries, function(a, b)
+  for line, items in pairs(merged_rows) do
+    table.sort(items, function(a, b)
       if a.col == b.col then
         return a.title < b.title
       end
@@ -233,20 +196,39 @@ local function render(bufnr, state)
       return a.col < b.col
     end)
 
-    local opts = { hl_mode = 'combine' }
-    local chunks = build_chunks(entries, placement)
+    if #items > 0 then
+      ---@type [string, string][]
+      local virt_text = { { '  ', 'LspCodeLensSeparator' } }
 
-    if placement == 'above' then
-      opts.virt_lines = { chunks }
-      opts.virt_lines_above = true
-      opts.virt_lines_overflow = 'scroll'
-    else
-      opts.virt_text = chunks
-      opts.virt_text_pos = 'eol'
+      for index, item in ipairs(items) do
+        virt_text[#virt_text + 1] = { item.title, 'LspCodeLens' }
+        if index < #items then
+          virt_text[#virt_text + 1] = { ' | ', 'LspCodeLensSeparator' }
+        end
+      end
+
+      api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
+        virt_text = virt_text,
+        virt_text_pos = 'eol',
+        hl_mode = 'combine',
+      })
     end
-
-    api.nvim_buf_set_extmark(bufnr, namespace, line, 0, opts)
   end
+end
+
+---@param lenses lsp.CodeLens[]?
+---@return table<integer, lsp.CodeLens[]>
+local function group_lenses(lenses)
+  local rows = {}
+
+  for _, lens in ipairs(lenses or {}) do
+    local line = lens.range.start.line
+    local row_lenses = rows[line] or {}
+    row_lenses[#row_lenses + 1] = lens
+    rows[line] = row_lenses
+  end
+
+  return rows
 end
 
 ---@param client vim.lsp.Client
@@ -254,36 +236,32 @@ end
 ---@param state dotfiles.LspCodeLensState
 ---@param seq integer
 ---@param tick integer
----@param lenses lsp.CodeLens[]?
----@param done fun(rows: table<integer, dotfiles.LspCodeLensEntry[]>)
-local function resolve_rows(client, bufnr, state, seq, tick, lenses, done)
-  ---@type table<integer, dotfiles.LspCodeLensEntry[]>
-  local rows = {}
-  local pending = 1
-  local can_resolve = client:supports_method(Methods.codeLens_resolve, bufnr)
-
-  local function finish()
-    pending = pending - 1
-    if pending == 0 then
-      done(rows)
+---@param unresolved_lens lsp.CodeLens
+local function resolve_lens(client, bufnr, state, seq, tick, unresolved_lens)
+  client:request(Methods.codeLens_resolve, unresolved_lens, function(err, resolved_lens)
+    if err or not resolved_lens or not is_refresh_current(bufnr, state, seq, tick) then
+      return
     end
-  end
 
-  for _, lens in ipairs(lenses or {}) do
-    if lens.command then
-      add_entry(rows, lens)
-    elseif can_resolve then
-      pending = pending + 1
-      client:request(Methods.codeLens_resolve, lens, function(err, resolved_lens)
-        if not err and is_refresh_current(bufnr, state, seq, tick) then
-          add_entry(rows, resolved_lens)
-        end
-        finish()
-      end, bufnr)
+    local client_rows = state.client_rows[client.id]
+    if not client_rows then
+      return
     end
-  end
 
-  finish()
+    local row = unresolved_lens.range.start.line
+    local row_lenses = client_rows[row]
+    if not row_lenses then
+      return
+    end
+
+    for index, lens in ipairs(row_lenses) do
+      if lens == unresolved_lens then
+        row_lenses[index] = resolved_lens
+        render(bufnr, state)
+        return
+      end
+    end
+  end, bufnr)
 end
 
 ---@param bufnr integer
@@ -302,9 +280,8 @@ local function refresh_now(bufnr)
   local params = { textDocument = vim.lsp.util.make_text_document_params(bufnr) }
   local requested = false
 
-  for client_id in pairs(state.clients) do
-    local client = vim.lsp.get_client_by_id(client_id)
-    if client and client:supports_method(Methods.textDocument_codeLens, bufnr) then
+  for _, client in ipairs(vim.lsp.get_clients({ bufnr = bufnr })) do
+    if client:supports_method(Methods.textDocument_codeLens, bufnr) then
       requested = true
       client:request(Methods.textDocument_codeLens, params, function(err, result)
         if not is_refresh_current(bufnr, state, seq, tick) then
@@ -312,19 +289,24 @@ local function refresh_now(bufnr)
         end
 
         if err then
-          state.client_rows[client_id] = {}
+          state.client_rows[client.id] = {}
           render(bufnr, state)
           return
         end
 
-        resolve_rows(client, bufnr, state, seq, tick, result, function(rows)
-          if not is_refresh_current(bufnr, state, seq, tick) then
-            return
-          end
+        local rows = group_lenses(result)
+        state.client_rows[client.id] = rows
+        render(bufnr, state)
 
-          state.client_rows[client_id] = rows
-          render(bufnr, state)
-        end)
+        if client:supports_method(Methods.codeLens_resolve, bufnr) then
+          for _, row_lenses in pairs(rows) do
+            for _, lens in ipairs(row_lenses) do
+              if not lens.command then
+                resolve_lens(client, bufnr, state, seq, tick, lens)
+              end
+            end
+          end
+        end
       end, bufnr)
     end
   end
@@ -335,6 +317,19 @@ local function refresh_now(bufnr)
 end
 
 ---@param bufnr integer
+local function enable_builtin(bufnr)
+  if api.nvim_buf_is_valid(bufnr) then
+    vim.lsp.codelens.enable(true, { bufnr = bufnr })
+  end
+end
+
+---@param bufnr integer
+local function disable_builtin(bufnr)
+  if api.nvim_buf_is_valid(bufnr) then
+    vim.lsp.codelens.enable(false, { bufnr = bufnr })
+  end
+end
+
 function M.clear(bufnr)
   local state = get_state(bufnr)
   if not state then
@@ -347,7 +342,6 @@ function M.clear(bufnr)
   clear_extmarks(bufnr)
 end
 
----@param bufnr integer
 function M.schedule_refresh(bufnr)
   local state = get_state(bufnr)
   if not state then
@@ -360,51 +354,22 @@ function M.schedule_refresh(bufnr)
   end, refresh_delay_ms)
 end
 
----@param bufnr integer
 function M.refresh(bufnr)
   refresh_now(bufnr)
 end
 
----@param client vim.lsp.Client
 ---@param bufnr integer
-function M.attach(client, bufnr)
-  if not client or not api.nvim_buf_is_valid(bufnr) then
-    return
-  end
-
-  local state = ensure_state(bufnr)
-  state.clients[client.id] = true
-  refresh_now(bufnr)
-end
-
----@param bufnr integer
----@param client_id integer
-function M.detach(bufnr, client_id)
+---@return boolean
+function M.is_context_active(bufnr)
   local state = get_state(bufnr)
-  if not state or not state.clients[client_id] then
-    return
-  end
-
-  state.clients[client_id] = nil
-  state.client_rows[client_id] = nil
-
-  if next(state.clients) == nil then
-    M.clear(bufnr)
-    if next(state.contexts) == nil then
-      M.detach_all(bufnr)
-    end
-    return
-  end
-
-  M.clear(bufnr)
-  refresh_now(bufnr)
+  return state ~= nil and has_contexts(state)
 end
 
 ---@param bufnr integer
 ---@param key string
----@param placement dotfiles.LspCodeLensPlacement
+---@param placement 'eol'
 function M.set_context(bufnr, key, placement)
-  if not api.nvim_buf_is_valid(bufnr) then
+  if placement ~= 'eol' or not api.nvim_buf_is_valid(bufnr) then
     return
   end
 
@@ -413,8 +378,15 @@ function M.set_context(bufnr, key, placement)
     return
   end
 
+  local was_inactive = not has_contexts(state)
   state.contexts[key] = placement
-  render(bufnr, state)
+
+  if was_inactive then
+    disable_builtin(bufnr)
+    refresh_now(bufnr)
+  else
+    render(bufnr, state)
+  end
 end
 
 ---@param bufnr integer
@@ -426,12 +398,13 @@ function M.clear_context(bufnr, key)
   end
 
   state.contexts[key] = nil
-  if next(state.clients) == nil and next(state.contexts) == nil then
-    M.detach_all(bufnr)
+  if has_contexts(state) then
+    render(bufnr, state)
     return
   end
 
-  render(bufnr, state)
+  M.detach_all(bufnr)
+  enable_builtin(bufnr)
 end
 
 ---@param bufnr integer
@@ -447,5 +420,15 @@ function M.detach_all(bufnr)
   clear_extmarks(bufnr)
   pcall(api.nvim_clear_autocmds, { group = augroup, buffer = bufnr })
 end
+
+api.nvim_create_autocmd({ 'LspAttach', 'LspDetach' }, {
+  group = augroup,
+  callback = function(args)
+    local state = get_state(args.buf)
+    if state and has_contexts(state) then
+      M.schedule_refresh(args.buf)
+    end
+  end,
+})
 
 return M

--- a/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
+++ b/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
@@ -4,7 +4,9 @@ local Methods = vim.lsp.protocol.Methods
 local M = {}
 
 local namespace = api.nvim_create_namespace('dotfiles.lsp.codelens')
-local augroup = api.nvim_create_augroup('dotfiles-lsp-codelens', { clear = false })
+-- Clear on load so re-sourcing this module replaces stale global callbacks
+-- instead of stacking multiple LspAttach/LspDetach handlers.
+local augroup = api.nvim_create_augroup('dotfiles-lsp-codelens', { clear = true })
 local refresh_delay_ms = 200
 
 ---@class dotfiles.LspCodeLensState

--- a/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
+++ b/home/.chezmoitemplates/nvim/lua/utils/lsp_codelens.lua
@@ -6,6 +6,14 @@ local M = {}
 local namespace = api.nvim_create_namespace('dotfiles.lsp.codelens')
 local augroup = api.nvim_create_augroup('dotfiles-lsp-codelens', { clear = false })
 local refresh_delay_ms = 200
+local default_placement = 'above'
+
+local context_priority = {
+  gitsigns_blame = 20,
+  diffview = 10,
+}
+
+---@alias dotfiles.LspCodeLensPlacement 'above'|'eol'
 
 ---@class dotfiles.LspCodeLensEntry
 ---@field col integer
@@ -14,6 +22,7 @@ local refresh_delay_ms = 200
 ---@class dotfiles.LspCodeLensState
 ---@field clients table<integer, true>
 ---@field client_rows table<integer, table<integer, dotfiles.LspCodeLensEntry[]>>
+---@field contexts table<string, dotfiles.LspCodeLensPlacement>
 ---@field refresh_seq integer
 ---@field timer? uv.uv_timer_t
 
@@ -71,6 +80,7 @@ local function ensure_state(bufnr)
   state = {
     clients = {},
     client_rows = {},
+    contexts = {},
     refresh_seq = 0,
   }
   states[bufnr] = state
@@ -120,6 +130,23 @@ local function ensure_state(bufnr)
 end
 
 ---@param state dotfiles.LspCodeLensState
+---@return dotfiles.LspCodeLensPlacement
+local function get_placement(state)
+  local best_priority = -1
+  local placement = default_placement
+
+  for key, override in pairs(state.contexts) do
+    local priority = context_priority[key] or 0
+    if override and priority > best_priority then
+      best_priority = priority
+      placement = override
+    end
+  end
+
+  return placement
+end
+
+---@param state dotfiles.LspCodeLensState
 ---@param seq integer
 ---@param tick integer
 ---@return boolean
@@ -151,9 +178,35 @@ local function add_entry(rows, lens)
   rows[line] = entries
 end
 
+---@param entries dotfiles.LspCodeLensEntry[]
+---@param placement dotfiles.LspCodeLensPlacement
+---@return [string, string][]
+local function build_chunks(entries, placement)
+  ---@type [string, string][]
+  local virt_text = {}
+
+  if placement == 'above' then
+    local indent = math.max(entries[1].col, 0)
+    if indent > 0 then
+      virt_text[#virt_text + 1] = { string.rep(' ', indent), 'LspCodeLensSeparator' }
+    end
+  else
+    virt_text[#virt_text + 1] = { '  ', 'LspCodeLensSeparator' }
+  end
+
+  for index, entry in ipairs(entries) do
+    virt_text[#virt_text + 1] = { entry.title, 'LspCodeLens' }
+    if index < #entries then
+      virt_text[#virt_text + 1] = { ' | ', 'LspCodeLensSeparator' }
+    end
+  end
+
+  return virt_text
+end
+
 ---@param bufnr integer
----@param client_rows table<integer, table<integer, dotfiles.LspCodeLensEntry[]>>
-local function render(bufnr, client_rows)
+---@param state dotfiles.LspCodeLensState
+local function render(bufnr, state)
   if not api.nvim_buf_is_valid(bufnr) then
     return
   end
@@ -162,7 +215,7 @@ local function render(bufnr, client_rows)
 
   ---@type table<integer, dotfiles.LspCodeLensEntry[]>
   local merged_rows = {}
-  for _, rows in pairs(client_rows) do
+  for _, rows in pairs(state.client_rows) do
     for line, entries in pairs(rows) do
       local merged = merged_rows[line] or {}
       vim.list_extend(merged, entries)
@@ -170,6 +223,7 @@ local function render(bufnr, client_rows)
     end
   end
 
+  local placement = get_placement(state)
   for line, entries in pairs(merged_rows) do
     table.sort(entries, function(a, b)
       if a.col == b.col then
@@ -179,20 +233,19 @@ local function render(bufnr, client_rows)
       return a.col < b.col
     end)
 
-    ---@type [string, string][]
-    local virt_text = { { '  ', 'LspCodeLensSeparator' } }
-    for index, entry in ipairs(entries) do
-      virt_text[#virt_text + 1] = { entry.title, 'LspCodeLens' }
-      if index < #entries then
-        virt_text[#virt_text + 1] = { ' | ', 'LspCodeLensSeparator' }
-      end
+    local opts = { hl_mode = 'combine' }
+    local chunks = build_chunks(entries, placement)
+
+    if placement == 'above' then
+      opts.virt_lines = { chunks }
+      opts.virt_lines_above = true
+      opts.virt_lines_overflow = 'scroll'
+    else
+      opts.virt_text = chunks
+      opts.virt_text_pos = 'eol'
     end
 
-    api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
-      virt_text = virt_text,
-      virt_text_pos = 'eol',
-      hl_mode = 'combine',
-    })
+    api.nvim_buf_set_extmark(bufnr, namespace, line, 0, opts)
   end
 end
 
@@ -260,7 +313,7 @@ local function refresh_now(bufnr)
 
         if err then
           state.client_rows[client_id] = {}
-          render(bufnr, state.client_rows)
+          render(bufnr, state)
           return
         end
 
@@ -270,7 +323,7 @@ local function refresh_now(bufnr)
           end
 
           state.client_rows[client_id] = rows
-          render(bufnr, state.client_rows)
+          render(bufnr, state)
         end)
       end, bufnr)
     end
@@ -336,12 +389,49 @@ function M.detach(bufnr, client_id)
   state.client_rows[client_id] = nil
 
   if next(state.clients) == nil then
-    M.detach_all(bufnr)
+    M.clear(bufnr)
+    if next(state.contexts) == nil then
+      M.detach_all(bufnr)
+    end
     return
   end
 
   M.clear(bufnr)
   refresh_now(bufnr)
+end
+
+---@param bufnr integer
+---@param key string
+---@param placement dotfiles.LspCodeLensPlacement
+function M.set_context(bufnr, key, placement)
+  if not api.nvim_buf_is_valid(bufnr) then
+    return
+  end
+
+  local state = ensure_state(bufnr)
+  if state.contexts[key] == placement then
+    return
+  end
+
+  state.contexts[key] = placement
+  render(bufnr, state)
+end
+
+---@param bufnr integer
+---@param key string
+function M.clear_context(bufnr, key)
+  local state = get_state(bufnr)
+  if not state or not state.contexts[key] then
+    return
+  end
+
+  state.contexts[key] = nil
+  if next(state.clients) == nil and next(state.contexts) == nil then
+    M.detach_all(bufnr)
+    return
+  end
+
+  render(bufnr, state)
 end
 
 ---@param bufnr integer

--- a/home/.chezmoitemplates/nvim/tests/plenary/spec/git_diffview_codelens_spec.lua
+++ b/home/.chezmoitemplates/nvim/tests/plenary/spec/git_diffview_codelens_spec.lua
@@ -1,0 +1,182 @@
+local function make_emitter()
+  local listeners = {}
+
+  return {
+    listeners = listeners,
+    on = function(_, event, callback)
+      local callbacks = listeners[event] or {}
+      callbacks[#callbacks + 1] = callback
+      listeners[event] = callbacks
+    end,
+    emit = function(_, event, ...)
+      for _, callback in ipairs(listeners[event] or {}) do
+        callback(...)
+      end
+    end,
+  }
+end
+
+describe('plugins.git Diffview CodeLens sync', function()
+  local stubbed_module_names = {
+    'utils.lsp_codelens',
+    'configs.project.options',
+    'neogit',
+    'diffview',
+    'diffview.lib',
+    'plugins.git',
+  }
+  local original_modules
+  local original_keymap_set
+  local created_bufs
+  local hooks
+  local current_view
+  local codelens_calls
+
+  local function make_buf(name)
+    local bufnr = vim.api.nvim_create_buf(false, true)
+    if name then
+      vim.api.nvim_buf_set_name(bufnr, name)
+    end
+    created_bufs[#created_bufs + 1] = bufnr
+    return bufnr
+  end
+
+  local function make_view(main_buf)
+    local emitter = make_emitter()
+    local view = {
+      emitter = emitter,
+      cur_layout = {
+        get_main_win = function()
+          return {
+            id = vim.api.nvim_get_current_win(),
+            file = { bufnr = main_buf },
+          }
+        end,
+      },
+    }
+
+    return view, emitter
+  end
+
+  before_each(function()
+    original_modules = {}
+    created_bufs = {}
+    hooks = nil
+    current_view = nil
+    codelens_calls = {}
+
+    for _, module_name in ipairs(stubbed_module_names) do
+      original_modules[module_name] = package.loaded[module_name]
+      package.loaded[module_name] = nil
+    end
+
+    package.loaded['utils.lsp_codelens'] = {
+      set_context = function(bufnr, key, placement)
+        codelens_calls[#codelens_calls + 1] = {
+          fn = 'set_context',
+          bufnr = bufnr,
+          key = key,
+          placement = placement,
+        }
+      end,
+      clear_context = function(bufnr, key)
+        codelens_calls[#codelens_calls + 1] = {
+          fn = 'clear_context',
+          bufnr = bufnr,
+          key = key,
+        }
+      end,
+    }
+    package.loaded['configs.project.options'] = {
+      apply_filetype_settings_for_root = function() end,
+    }
+    package.loaded['neogit'] = {
+      setup = function() end,
+      open = function() end,
+    }
+    package.loaded['diffview'] = {
+      setup = function(config)
+        hooks = config.hooks
+      end,
+      emit = function() end,
+    }
+    package.loaded['diffview.lib'] = {
+      get_current_view = function()
+        return current_view
+      end,
+    }
+
+    original_keymap_set = vim.keymap.set
+    vim.keymap.set = function() end
+  end)
+
+  after_each(function()
+    vim.keymap.set = original_keymap_set
+
+    for _, bufnr in ipairs(created_bufs) do
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+      end
+    end
+
+    for _, module_name in ipairs(stubbed_module_names) do
+      package.loaded[module_name] = original_modules[module_name]
+    end
+  end)
+
+  it('seeds Diffview CodeLens ownership on view_opened', function()
+    local spec = require('plugins.git')[1]
+    spec.config()
+
+    assert.is_table(hooks)
+
+    local buf1 = make_buf('diffview://repo/1/file1')
+    local view = make_view(buf1)
+    current_view = view
+
+    hooks.view_opened(view)
+
+    assert.same({
+      {
+        fn = 'set_context',
+        bufnr = buf1,
+        key = 'diffview',
+        placement = 'eol',
+      },
+    }, codelens_calls)
+  end)
+
+  it('keeps view_enter as a defensive resync when returning to a Diffview tab', function()
+    local spec = require('plugins.git')[1]
+    spec.config()
+
+    assert.is_table(hooks)
+
+    local buf1 = make_buf('diffview://repo/1/file1')
+    local buf2 = make_buf('diffview://repo/1/file2')
+    local view = make_view(buf1)
+    current_view = view
+
+    hooks.view_opened(view)
+    hooks.view_leave()
+
+    codelens_calls = {}
+    view.cur_layout.get_main_win = function()
+      return {
+        id = vim.api.nvim_get_current_win(),
+        file = { bufnr = buf2 },
+      }
+    end
+
+    hooks.view_enter(view)
+
+    assert.same({
+      {
+        fn = 'set_context',
+        bufnr = buf2,
+        key = 'diffview',
+        placement = 'eol',
+      },
+    }, codelens_calls)
+  end)
+end)

--- a/home/.chezmoitemplates/nvim/tests/plenary/spec/lsp_codelens_spec.lua
+++ b/home/.chezmoitemplates/nvim/tests/plenary/spec/lsp_codelens_spec.lua
@@ -21,17 +21,34 @@ local function make_buf(lines)
   return bufnr
 end
 
+local function join_chunks(chunks)
+  local parts = {}
+
+  for _, chunk in ipairs(chunks or {}) do
+    parts[#parts + 1] = chunk[1]
+  end
+
+  return table.concat(parts)
+end
+
 local function get_rendered_rows(bufnr)
   local ns = vim.api.nvim_get_namespaces()[namespace]
   local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
   local rows = {}
 
   for _, extmark in ipairs(extmarks) do
-    local chunks = {}
-    for _, chunk in ipairs(extmark[4].virt_text or {}) do
-      chunks[#chunks + 1] = chunk[1]
+    local details = extmark[4]
+    if details.virt_text then
+      rows[extmark[2]] = {
+        placement = 'eol',
+        text = join_chunks(details.virt_text),
+      }
+    elseif details.virt_lines and details.virt_lines[1] then
+      rows[extmark[2]] = {
+        placement = 'above',
+        text = join_chunks(details.virt_lines[1]),
+      }
     end
-    rows[extmark[2]] = table.concat(chunks)
   end
 
   return rows
@@ -63,7 +80,7 @@ describe('utils.lsp_codelens', function()
     end
   end)
 
-  it('renders same-line virtual text aggregated across clients', function()
+  it('renders above-line virtual text aggregated across clients by default', function()
     local bufnr = make_buf({ 'local value = 1', 'return value' })
     table.insert(buffers, bufnr)
 
@@ -72,7 +89,7 @@ describe('utils.lsp_codelens', function()
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens
       end,
-      request = function(_, method, _, callback)
+      request = function(_, _, _, callback)
         callback(nil, {
           {
             range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
@@ -87,7 +104,7 @@ describe('utils.lsp_codelens', function()
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens
       end,
-      request = function(_, method, _, callback)
+      request = function(_, _, _, callback)
         callback(nil, {
           {
             range = { start = { line = 0, character = 6 }, ['end'] = { line = 0, character = 6 } },
@@ -106,8 +123,59 @@ describe('utils.lsp_codelens', function()
 
     wait_for('expected aggregated codelens render', function()
       local rows = get_rendered_rows(bufnr)
-      return rows[0] == '  3 References | 1 Implementation' and rows[1] == '  Run Test'
+      return rows[0]
+        and rows[0].placement == 'above'
+        and rows[0].text == '3 References | 1 Implementation'
+        and rows[1]
+        and rows[1].placement == 'above'
+        and rows[1].text == 'Run Test'
     end)
+  end)
+
+  it('switches placement from above to eol and back without new requests', function()
+    local bufnr = make_buf({ 'local value = 1' })
+    table.insert(buffers, bufnr)
+
+    local request_count = 0
+    clients[1] = {
+      id = 1,
+      supports_method = function(_, method)
+        return method == Methods.textDocument_codeLens
+      end,
+      request = function(_, _, _, callback)
+        request_count = request_count + 1
+        callback(nil, {
+          {
+            range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
+            command = { title = 'Lens Title' },
+          },
+        })
+      end,
+    }
+
+    codelens.attach(clients[1], bufnr)
+
+    wait_for('expected default above-line codelens', function()
+      local row = get_rendered_rows(bufnr)[0]
+      return row and row.placement == 'above' and row.text == 'Lens Title'
+    end)
+    assert.equals(1, request_count)
+
+    codelens.set_context(bufnr, 'diffview', 'eol')
+
+    wait_for('expected eol codelens override', function()
+      local row = get_rendered_rows(bufnr)[0]
+      return row and row.placement == 'eol' and row.text == '  Lens Title'
+    end)
+    assert.equals(1, request_count)
+
+    codelens.clear_context(bufnr, 'diffview')
+
+    wait_for('expected above-line codelens after clearing override', function()
+      local row = get_rendered_rows(bufnr)[0]
+      return row and row.placement == 'above' and row.text == 'Lens Title'
+    end)
+    assert.equals(1, request_count)
   end)
 
   it('clears while editing and ignores stale responses from older refreshes', function()
@@ -122,7 +190,7 @@ describe('utils.lsp_codelens', function()
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens
       end,
-      request = function(_, method, _, callback)
+      request = function(_, _, _, callback)
         request_count = request_count + 1
         if request_count == 1 then
           first_callback = callback
@@ -146,7 +214,8 @@ describe('utils.lsp_codelens', function()
     vim.api.nvim_exec_autocmds('InsertLeave', { buffer = bufnr })
 
     wait_for('expected fresh codelens after insert leave', function()
-      return get_rendered_rows(bufnr)[0] == '  Fresh Lens'
+      local row = get_rendered_rows(bufnr)[0]
+      return row and row.placement == 'above' and row.text == 'Fresh Lens'
     end)
 
     first_callback(nil, {
@@ -160,7 +229,8 @@ describe('utils.lsp_codelens', function()
       return false
     end, 10, false)
 
-    assert.equals('  Fresh Lens', get_rendered_rows(bufnr)[0])
+    local row = get_rendered_rows(bufnr)[0]
+    assert.same({ placement = 'above', text = 'Fresh Lens' }, row)
   end)
 
   it('resolves unresolved lenses before rendering their titles', function()
@@ -198,7 +268,8 @@ describe('utils.lsp_codelens', function()
     codelens.attach(clients[1], bufnr)
 
     wait_for('expected resolved codelens title', function()
-      return get_rendered_rows(bufnr)[0] == '  Resolved Lens'
+      local row = get_rendered_rows(bufnr)[0]
+      return row and row.placement == 'above' and row.text == 'Resolved Lens'
     end)
   end)
 
@@ -211,7 +282,7 @@ describe('utils.lsp_codelens', function()
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens
       end,
-      request = function(_, method, _, callback)
+      request = function(_, _, _, callback)
         callback(nil, {
           {
             range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
@@ -224,7 +295,8 @@ describe('utils.lsp_codelens', function()
     codelens.attach(clients[1], bufnr)
 
     wait_for('expected initial codelens render', function()
-      return get_rendered_rows(bufnr)[0] == '  Detached Lens'
+      local row = get_rendered_rows(bufnr)[0]
+      return row and row.placement == 'above' and row.text == 'Detached Lens'
     end)
 
     codelens.detach(bufnr, 1)

--- a/home/.chezmoitemplates/nvim/tests/plenary/spec/lsp_codelens_spec.lua
+++ b/home/.chezmoitemplates/nvim/tests/plenary/spec/lsp_codelens_spec.lua
@@ -1,0 +1,235 @@
+local codelens = require('utils.lsp_codelens')
+
+local Methods = vim.lsp.protocol.Methods
+local namespace = 'dotfiles.lsp.codelens'
+local augroup = 'dotfiles-lsp-codelens'
+
+local function wait_for(message, predicate, timeout)
+  local ok = vim.wait(timeout or 1000, function()
+    local status, done = pcall(predicate)
+    return status and done
+  end, 10, false)
+
+  if not ok then
+    error(message)
+  end
+end
+
+local function make_buf(lines)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  return bufnr
+end
+
+local function get_rendered_rows(bufnr)
+  local ns = vim.api.nvim_get_namespaces()[namespace]
+  local extmarks = vim.api.nvim_buf_get_extmarks(bufnr, ns, 0, -1, { details = true })
+  local rows = {}
+
+  for _, extmark in ipairs(extmarks) do
+    local chunks = {}
+    for _, chunk in ipairs(extmark[4].virt_text or {}) do
+      chunks[#chunks + 1] = chunk[1]
+    end
+    rows[extmark[2]] = table.concat(chunks)
+  end
+
+  return rows
+end
+
+describe('utils.lsp_codelens', function()
+  local original_get_client_by_id
+  local buffers
+  local clients
+
+  before_each(function()
+    original_get_client_by_id = vim.lsp.get_client_by_id
+    buffers = {}
+    clients = {}
+
+    vim.lsp.get_client_by_id = function(id)
+      return clients[id]
+    end
+  end)
+
+  after_each(function()
+    vim.lsp.get_client_by_id = original_get_client_by_id
+
+    for _, bufnr in ipairs(buffers) do
+      codelens.detach_all(bufnr)
+      if vim.api.nvim_buf_is_valid(bufnr) then
+        pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+      end
+    end
+  end)
+
+  it('renders same-line virtual text aggregated across clients', function()
+    local bufnr = make_buf({ 'local value = 1', 'return value' })
+    table.insert(buffers, bufnr)
+
+    clients[1] = {
+      id = 1,
+      supports_method = function(_, method)
+        return method == Methods.textDocument_codeLens
+      end,
+      request = function(_, method, _, callback)
+        callback(nil, {
+          {
+            range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
+            command = { title = '3 References' },
+          },
+        })
+      end,
+    }
+
+    clients[2] = {
+      id = 2,
+      supports_method = function(_, method)
+        return method == Methods.textDocument_codeLens
+      end,
+      request = function(_, method, _, callback)
+        callback(nil, {
+          {
+            range = { start = { line = 0, character = 6 }, ['end'] = { line = 0, character = 6 } },
+            command = { title = '1 Implementation' },
+          },
+          {
+            range = { start = { line = 1, character = 0 }, ['end'] = { line = 1, character = 0 } },
+            command = { title = 'Run Test' },
+          },
+        })
+      end,
+    }
+
+    codelens.attach(clients[1], bufnr)
+    codelens.attach(clients[2], bufnr)
+
+    wait_for('expected aggregated codelens render', function()
+      local rows = get_rendered_rows(bufnr)
+      return rows[0] == '  3 References | 1 Implementation' and rows[1] == '  Run Test'
+    end)
+  end)
+
+  it('clears while editing and ignores stale responses from older refreshes', function()
+    local bufnr = make_buf({ 'local value = 1' })
+    table.insert(buffers, bufnr)
+
+    local request_count = 0
+    local first_callback
+
+    clients[1] = {
+      id = 1,
+      supports_method = function(_, method)
+        return method == Methods.textDocument_codeLens
+      end,
+      request = function(_, method, _, callback)
+        request_count = request_count + 1
+        if request_count == 1 then
+          first_callback = callback
+          return
+        end
+
+        callback(nil, {
+          {
+            range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
+            command = { title = 'Fresh Lens' },
+          },
+        })
+      end,
+    }
+
+    codelens.attach(clients[1], bufnr)
+
+    vim.api.nvim_exec_autocmds('InsertEnter', { buffer = bufnr })
+    assert.same({}, get_rendered_rows(bufnr))
+
+    vim.api.nvim_exec_autocmds('InsertLeave', { buffer = bufnr })
+
+    wait_for('expected fresh codelens after insert leave', function()
+      return get_rendered_rows(bufnr)[0] == '  Fresh Lens'
+    end)
+
+    first_callback(nil, {
+      {
+        range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
+        command = { title = 'Stale Lens' },
+      },
+    })
+
+    vim.wait(50, function()
+      return false
+    end, 10, false)
+
+    assert.equals('  Fresh Lens', get_rendered_rows(bufnr)[0])
+  end)
+
+  it('resolves unresolved lenses before rendering their titles', function()
+    local bufnr = make_buf({ 'function demo() end' })
+    table.insert(buffers, bufnr)
+
+    clients[1] = {
+      id = 1,
+      supports_method = function(_, method)
+        return method == Methods.textDocument_codeLens or method == Methods.codeLens_resolve
+      end,
+      request = function(_, method, params, callback)
+        if method == Methods.textDocument_codeLens then
+          callback(nil, {
+            {
+              range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
+              data = { id = 'unresolved' },
+            },
+          })
+          return
+        end
+
+        assert.same({ id = 'unresolved' }, params.data)
+        vim.schedule(function()
+          callback(
+            nil,
+            vim.tbl_deep_extend('force', params, {
+              command = { title = 'Resolved Lens' },
+            })
+          )
+        end)
+      end,
+    }
+
+    codelens.attach(clients[1], bufnr)
+
+    wait_for('expected resolved codelens title', function()
+      return get_rendered_rows(bufnr)[0] == '  Resolved Lens'
+    end)
+  end)
+
+  it('cleans up extmarks and autocmds when the last client detaches', function()
+    local bufnr = make_buf({ 'return 1' })
+    table.insert(buffers, bufnr)
+
+    clients[1] = {
+      id = 1,
+      supports_method = function(_, method)
+        return method == Methods.textDocument_codeLens
+      end,
+      request = function(_, method, _, callback)
+        callback(nil, {
+          {
+            range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
+            command = { title = 'Detached Lens' },
+          },
+        })
+      end,
+    }
+
+    codelens.attach(clients[1], bufnr)
+
+    wait_for('expected initial codelens render', function()
+      return get_rendered_rows(bufnr)[0] == '  Detached Lens'
+    end)
+
+    codelens.detach(bufnr, 1)
+
+    assert.same({}, get_rendered_rows(bufnr))
+    assert.same({}, vim.api.nvim_get_autocmds({ group = augroup, buffer = bufnr }))
+  end)
+end)

--- a/home/.chezmoitemplates/nvim/tests/plenary/spec/lsp_codelens_spec.lua
+++ b/home/.chezmoitemplates/nvim/tests/plenary/spec/lsp_codelens_spec.lua
@@ -166,6 +166,31 @@ describe('utils.lsp_codelens', function()
         and rows[1].text == '  Run Test'
     end)
 
+    assert.is_true(codelens.is_active(bufnr))
+    assert.same({
+      {
+        client_id = 1,
+        lens = {
+          range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
+          command = { title = '3 References' },
+        },
+      },
+      {
+        client_id = 2,
+        lens = {
+          range = { start = { line = 0, character = 6 }, ['end'] = { line = 0, character = 6 } },
+          command = { title = '1 Implementation' },
+        },
+      },
+      {
+        client_id = 2,
+        lens = {
+          range = { start = { line = 1, character = 0 }, ['end'] = { line = 1, character = 0 } },
+          command = { title = 'Run Test' },
+        },
+      },
+    }, codelens.get({ bufnr = bufnr }))
+
     assert.same({
       {
         enable = false,
@@ -291,10 +316,6 @@ describe('utils.lsp_codelens', function()
       },
     })
 
-    vim.wait(50, function()
-      return false
-    end, 10, false)
-
     local row = get_rendered_rows(bufnr)[0]
     assert.same({ placement = 'eol', text = '  Fresh Lens' }, row)
   end)
@@ -341,6 +362,100 @@ describe('utils.lsp_codelens', function()
     end)
   end)
 
+  it('coalesces multiple resolve callbacks into one render pass per tick', function()
+    local bufnr = make_buf({ 'function demo() end' })
+    table.insert(buffers, bufnr)
+
+    local original_set_extmark = vim.api.nvim_buf_set_extmark
+    local extmark_calls = 0
+    vim.api.nvim_buf_set_extmark = function(...)
+      extmark_calls = extmark_calls + 1
+      return original_set_extmark(...)
+    end
+
+    clients[1] = {
+      id = 1,
+      _bufnr = bufnr,
+      offset_encoding = 'utf-16',
+      supports_method = function(_, method)
+        return method == Methods.textDocument_codeLens or method == Methods.codeLens_resolve
+      end,
+      request = function(_, method, params, callback)
+        if method == Methods.textDocument_codeLens then
+          callback(nil, {
+            {
+              range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
+              data = { id = 'a' },
+            },
+            {
+              range = { start = { line = 0, character = 5 }, ['end'] = { line = 0, character = 5 } },
+              data = { id = 'b' },
+            },
+          })
+          return
+        end
+
+        vim.schedule(function()
+          callback(
+            nil,
+            vim.tbl_deep_extend('force', params, {
+              command = { title = params.data.id == 'a' and 'Lens A' or 'Lens B' },
+            })
+          )
+        end)
+      end,
+    }
+
+    local ok, err = pcall(function()
+      codelens.set_context(bufnr, 'diffview', 'eol')
+
+      wait_for('expected coalesced resolved codelens render', function()
+        local row = get_rendered_rows(bufnr)[0]
+        return row and row.placement == 'eol' and row.text == '  Lens A | Lens B'
+      end)
+
+      assert.equals(1, extmark_calls)
+    end)
+
+    vim.api.nvim_buf_set_extmark = original_set_extmark
+    if not ok then
+      error(err)
+    end
+  end)
+
+  it('ignores invalid rows from LSP data while keeping valid rows', function()
+    local bufnr = make_buf({ 'return value' })
+    table.insert(buffers, bufnr)
+
+    clients[1] = {
+      id = 1,
+      _bufnr = bufnr,
+      offset_encoding = 'utf-16',
+      supports_method = function(_, method)
+        return method == Methods.textDocument_codeLens
+      end,
+      request = function(_, _, _, callback)
+        callback(nil, {
+          {
+            range = { start = { line = 5, character = 0 }, ['end'] = { line = 5, character = 0 } },
+            command = { title = 'Out of Range' },
+          },
+          {
+            range = { start = { line = 0, character = 0 }, ['end'] = { line = 0, character = 0 } },
+            command = { title = 'Valid Lens' },
+          },
+        })
+      end,
+    }
+
+    codelens.set_context(bufnr, 'diffview', 'eol')
+
+    wait_for('expected valid codelens render for in-range row only', function()
+      local rows = get_rendered_rows(bufnr)
+      return rows[0] and rows[0].placement == 'eol' and rows[0].text == '  Valid Lens' and rows[5] == nil
+    end)
+  end)
+
   it('cleans up extmarks and autocmds when the final context clears', function()
     local bufnr = make_buf({ 'return 1' })
     table.insert(buffers, bufnr)
@@ -372,6 +487,8 @@ describe('utils.lsp_codelens', function()
     codelens.clear_context(bufnr, 'diffview')
 
     assert.same({}, get_rendered_rows(bufnr))
+    assert.is_false(codelens.is_active(bufnr))
+    assert.same({}, codelens.get({ bufnr = bufnr }))
     assert.same({}, vim.api.nvim_get_autocmds({ group = augroup, buffer = bufnr }))
     assert.same({
       {

--- a/home/.chezmoitemplates/nvim/tests/plenary/spec/lsp_codelens_spec.lua
+++ b/home/.chezmoitemplates/nvim/tests/plenary/spec/lsp_codelens_spec.lua
@@ -56,21 +56,53 @@ end
 
 describe('utils.lsp_codelens', function()
   local original_get_client_by_id
+  local original_get_clients
+  local original_enable
   local buffers
   local clients
+  local enable_calls
 
   before_each(function()
     original_get_client_by_id = vim.lsp.get_client_by_id
+    original_get_clients = vim.lsp.get_clients
+    original_enable = vim.lsp.codelens.enable
+
     buffers = {}
     clients = {}
+    enable_calls = {}
 
     vim.lsp.get_client_by_id = function(id)
       return clients[id]
+    end
+
+    vim.lsp.get_clients = function(filter)
+      local bufnr = filter and filter.bufnr or nil
+      local matched = {}
+
+      for _, client in pairs(clients) do
+        if bufnr == nil or client._bufnr == bufnr then
+          matched[#matched + 1] = client
+        end
+      end
+
+      table.sort(matched, function(a, b)
+        return a.id < b.id
+      end)
+      return matched
+    end
+
+    vim.lsp.codelens.enable = function(enable, filter)
+      enable_calls[#enable_calls + 1] = {
+        enable = enable,
+        bufnr = filter and filter.bufnr or nil,
+      }
     end
   end)
 
   after_each(function()
     vim.lsp.get_client_by_id = original_get_client_by_id
+    vim.lsp.get_clients = original_get_clients
+    vim.lsp.codelens.enable = original_enable
 
     for _, bufnr in ipairs(buffers) do
       codelens.detach_all(bufnr)
@@ -80,12 +112,14 @@ describe('utils.lsp_codelens', function()
     end
   end)
 
-  it('renders above-line virtual text aggregated across clients by default', function()
+  it('renders eol virtual text aggregated across clients when a context is active', function()
     local bufnr = make_buf({ 'local value = 1', 'return value' })
     table.insert(buffers, bufnr)
 
     clients[1] = {
       id = 1,
+      _bufnr = bufnr,
+      offset_encoding = 'utf-16',
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens
       end,
@@ -101,6 +135,8 @@ describe('utils.lsp_codelens', function()
 
     clients[2] = {
       id = 2,
+      _bufnr = bufnr,
+      offset_encoding = 'utf-16',
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens
       end,
@@ -118,27 +154,35 @@ describe('utils.lsp_codelens', function()
       end,
     }
 
-    codelens.attach(clients[1], bufnr)
-    codelens.attach(clients[2], bufnr)
+    codelens.set_context(bufnr, 'diffview', 'eol')
 
-    wait_for('expected aggregated codelens render', function()
+    wait_for('expected aggregated eol codelens render', function()
       local rows = get_rendered_rows(bufnr)
       return rows[0]
-        and rows[0].placement == 'above'
-        and rows[0].text == '3 References | 1 Implementation'
+        and rows[0].placement == 'eol'
+        and rows[0].text == '  3 References | 1 Implementation'
         and rows[1]
-        and rows[1].placement == 'above'
-        and rows[1].text == 'Run Test'
+        and rows[1].placement == 'eol'
+        and rows[1].text == '  Run Test'
     end)
+
+    assert.same({
+      {
+        enable = false,
+        bufnr = bufnr,
+      },
+    }, enable_calls)
   end)
 
-  it('switches placement from above to eol and back without new requests', function()
+  it('stacks contexts without new requests and re-enables built-in codelens on final clear', function()
     local bufnr = make_buf({ 'local value = 1' })
     table.insert(buffers, bufnr)
 
     local request_count = 0
     clients[1] = {
       id = 1,
+      _bufnr = bufnr,
+      offset_encoding = 'utf-16',
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens
       end,
@@ -153,29 +197,49 @@ describe('utils.lsp_codelens', function()
       end,
     }
 
-    codelens.attach(clients[1], bufnr)
-
-    wait_for('expected default above-line codelens', function()
-      local row = get_rendered_rows(bufnr)[0]
-      return row and row.placement == 'above' and row.text == 'Lens Title'
-    end)
-    assert.equals(1, request_count)
-
     codelens.set_context(bufnr, 'diffview', 'eol')
 
-    wait_for('expected eol codelens override', function()
+    wait_for('expected initial eol codelens', function()
       local row = get_rendered_rows(bufnr)[0]
       return row and row.placement == 'eol' and row.text == '  Lens Title'
     end)
     assert.equals(1, request_count)
 
-    codelens.clear_context(bufnr, 'diffview')
-
-    wait_for('expected above-line codelens after clearing override', function()
-      local row = get_rendered_rows(bufnr)[0]
-      return row and row.placement == 'above' and row.text == 'Lens Title'
-    end)
+    codelens.set_context(bufnr, 'gitsigns_blame', 'eol')
+    local row = get_rendered_rows(bufnr)[0]
+    assert.same({ placement = 'eol', text = '  Lens Title' }, row)
     assert.equals(1, request_count)
+    assert.same({
+      {
+        enable = false,
+        bufnr = bufnr,
+      },
+    }, enable_calls)
+
+    codelens.clear_context(bufnr, 'diffview')
+    row = get_rendered_rows(bufnr)[0]
+    assert.same({ placement = 'eol', text = '  Lens Title' }, row)
+    assert.equals(1, request_count)
+    assert.same({
+      {
+        enable = false,
+        bufnr = bufnr,
+      },
+    }, enable_calls)
+
+    codelens.clear_context(bufnr, 'gitsigns_blame')
+
+    assert.same({}, get_rendered_rows(bufnr))
+    assert.same({
+      {
+        enable = false,
+        bufnr = bufnr,
+      },
+      {
+        enable = true,
+        bufnr = bufnr,
+      },
+    }, enable_calls)
   end)
 
   it('clears while editing and ignores stale responses from older refreshes', function()
@@ -187,6 +251,8 @@ describe('utils.lsp_codelens', function()
 
     clients[1] = {
       id = 1,
+      _bufnr = bufnr,
+      offset_encoding = 'utf-16',
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens
       end,
@@ -206,7 +272,7 @@ describe('utils.lsp_codelens', function()
       end,
     }
 
-    codelens.attach(clients[1], bufnr)
+    codelens.set_context(bufnr, 'diffview', 'eol')
 
     vim.api.nvim_exec_autocmds('InsertEnter', { buffer = bufnr })
     assert.same({}, get_rendered_rows(bufnr))
@@ -215,7 +281,7 @@ describe('utils.lsp_codelens', function()
 
     wait_for('expected fresh codelens after insert leave', function()
       local row = get_rendered_rows(bufnr)[0]
-      return row and row.placement == 'above' and row.text == 'Fresh Lens'
+      return row and row.placement == 'eol' and row.text == '  Fresh Lens'
     end)
 
     first_callback(nil, {
@@ -230,7 +296,7 @@ describe('utils.lsp_codelens', function()
     end, 10, false)
 
     local row = get_rendered_rows(bufnr)[0]
-    assert.same({ placement = 'above', text = 'Fresh Lens' }, row)
+    assert.same({ placement = 'eol', text = '  Fresh Lens' }, row)
   end)
 
   it('resolves unresolved lenses before rendering their titles', function()
@@ -239,6 +305,8 @@ describe('utils.lsp_codelens', function()
 
     clients[1] = {
       id = 1,
+      _bufnr = bufnr,
+      offset_encoding = 'utf-16',
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens or method == Methods.codeLens_resolve
       end,
@@ -265,20 +333,22 @@ describe('utils.lsp_codelens', function()
       end,
     }
 
-    codelens.attach(clients[1], bufnr)
+    codelens.set_context(bufnr, 'diffview', 'eol')
 
     wait_for('expected resolved codelens title', function()
       local row = get_rendered_rows(bufnr)[0]
-      return row and row.placement == 'above' and row.text == 'Resolved Lens'
+      return row and row.placement == 'eol' and row.text == '  Resolved Lens'
     end)
   end)
 
-  it('cleans up extmarks and autocmds when the last client detaches', function()
+  it('cleans up extmarks and autocmds when the final context clears', function()
     local bufnr = make_buf({ 'return 1' })
     table.insert(buffers, bufnr)
 
     clients[1] = {
       id = 1,
+      _bufnr = bufnr,
+      offset_encoding = 'utf-16',
       supports_method = function(_, method)
         return method == Methods.textDocument_codeLens
       end,
@@ -292,16 +362,26 @@ describe('utils.lsp_codelens', function()
       end,
     }
 
-    codelens.attach(clients[1], bufnr)
+    codelens.set_context(bufnr, 'diffview', 'eol')
 
     wait_for('expected initial codelens render', function()
       local row = get_rendered_rows(bufnr)[0]
-      return row and row.placement == 'above' and row.text == 'Detached Lens'
+      return row and row.placement == 'eol' and row.text == '  Detached Lens'
     end)
 
-    codelens.detach(bufnr, 1)
+    codelens.clear_context(bufnr, 'diffview')
 
     assert.same({}, get_rendered_rows(bufnr))
     assert.same({}, vim.api.nvim_get_autocmds({ group = augroup, buffer = bufnr }))
+    assert.same({
+      {
+        enable = false,
+        bufnr = bufnr,
+      },
+      {
+        enable = true,
+        bufnr = bufnr,
+      },
+    }, enable_calls)
   end)
 end)

--- a/home/.chezmoitemplates/nvim/tests/plenary/spec/php_unused_refs_spec.lua
+++ b/home/.chezmoitemplates/nvim/tests/plenary/spec/php_unused_refs_spec.lua
@@ -3,6 +3,11 @@ local php = require('configs.lsp.php')
 local Methods = vim.lsp.protocol.Methods
 local config = php.lspconfigs[1].config
 
+-- This spec intentionally reaches into php.lua through named upvalues so it
+-- can exercise the real diagnostic helper without widening the runtime API.
+-- It is coupled to php.lua's private closure graph, not upvalue order: simple
+-- reordering is fine, but refactors that stop capturing these helpers will
+-- need to update this test.
 local function get_upvalue(fn, expected_name)
   for index = 1, 20 do
     local name, value = debug.getupvalue(fn, index)

--- a/home/.chezmoitemplates/nvim/tests/plenary/spec/php_unused_refs_spec.lua
+++ b/home/.chezmoitemplates/nvim/tests/plenary/spec/php_unused_refs_spec.lua
@@ -1,0 +1,145 @@
+local php = require('configs.lsp.php')
+
+local Methods = vim.lsp.protocol.Methods
+local config = php.lspconfigs[1].config
+
+local function get_upvalue(fn, expected_name)
+  for index = 1, 20 do
+    local name, value = debug.getupvalue(fn, index)
+    if not name then
+      break
+    end
+
+    if name == expected_name then
+      return value
+    end
+  end
+
+  error('missing upvalue: ' .. expected_name)
+end
+
+local schedule_unused_reference_refresh =
+  get_upvalue(config.on_attach, 'schedule_unused_reference_refresh')
+local refresh_unused_reference_diagnostics_from_cache =
+  get_upvalue(schedule_unused_reference_refresh, 'refresh_unused_reference_diagnostics_from_cache')
+local set_unused_reference_diagnostics =
+  get_upvalue(refresh_unused_reference_diagnostics_from_cache, 'set_unused_reference_diagnostics')
+
+local function make_buf(lines)
+  local bufnr = vim.api.nvim_create_buf(false, true)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  vim.bo[bufnr].filetype = 'php'
+  vim.api.nvim_set_current_buf(bufnr)
+  return bufnr
+end
+
+local function get_unused_reference_diagnostics(bufnr)
+  return vim.tbl_filter(function(diagnostic)
+    return diagnostic.source == 'intelephense' and diagnostic.code == 'P1003'
+  end, vim.diagnostic.get(bufnr))
+end
+
+local function assert_unused_reference_hint(bufnr)
+  local diagnostics = get_unused_reference_diagnostics(bufnr)
+  assert.equals(1, #diagnostics)
+  assert.same({
+    lnum = 1,
+    col = 9,
+    message = "Symbol 'unused' is declared but not used.",
+    severity = vim.diagnostic.severity.HINT,
+    source = 'intelephense',
+    code = 'P1003',
+  }, {
+    lnum = diagnostics[1].lnum,
+    col = diagnostics[1].col,
+    message = diagnostics[1].message,
+    severity = diagnostics[1].severity,
+    source = diagnostics[1].source,
+    code = diagnostics[1].code,
+  })
+end
+
+local function unresolved_unused_lens()
+  return {
+    range = {
+      start = { line = 1, character = 9 },
+      ['end'] = { line = 1, character = 15 },
+    },
+    data = { symbol = 'unused' },
+  }
+end
+
+describe('configs.lsp.php unused reference diagnostics', function()
+  local bufnr
+  local client
+  local requests
+
+  before_each(function()
+    requests = { resolve = 0 }
+
+    client = {
+      id = 9901,
+      name = 'intelephense',
+      offset_encoding = 'utf-16',
+    }
+
+    function client:supports_method(method)
+      return method == Methods.codeLens_resolve
+    end
+
+    function client:request(method, params, callback, target_bufnr)
+      assert.equals(Methods.codeLens_resolve, method)
+
+      requests.resolve = requests.resolve + 1
+      local line = vim.api.nvim_buf_get_lines(target_bufnr, 1, 2, false)[1] or ''
+      assert.matches('^function unused', line)
+
+      local resolved_lens = vim.deepcopy(params)
+      resolved_lens.command = { title = '0 References' }
+      callback(nil, resolved_lens)
+    end
+  end)
+
+  after_each(function()
+    if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
+      pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
+    end
+  end)
+
+  local function apply_fallback_lenses()
+    local lens = unresolved_unused_lens()
+
+    if client:supports_method(Methods.codeLens_resolve, bufnr) then
+      client:request(Methods.codeLens_resolve, lens, function(err, resolved_lens)
+        assert.is_nil(err)
+        set_unused_reference_diagnostics(bufnr, client, { resolved_lens })
+      end, bufnr)
+      return
+    end
+
+    set_unused_reference_diagnostics(bufnr, client, { lens })
+  end
+
+  it('restores the unused-reference hint after delete and restore when fallback lenses require resolve', function()
+    bufnr = make_buf({
+      '<?php',
+      'function unused() {}',
+      "echo 'ready';",
+    })
+
+    apply_fallback_lenses()
+
+    assert.equals(1, requests.resolve)
+    assert_unused_reference_hint(bufnr)
+
+    requests.resolve = 0
+
+    vim.api.nvim_buf_set_lines(bufnr, 1, 2, false, {})
+    vim.api.nvim_buf_set_lines(bufnr, 1, 1, false, { 'function unused() {}' })
+
+    apply_fallback_lenses()
+
+    assert.equals(1, requests.resolve)
+    assert_unused_reference_hint(bufnr)
+  end)
+end)

--- a/home/.chezmoitemplates/nvim/tests/plenary/spec/php_unused_refs_spec.lua
+++ b/home/.chezmoitemplates/nvim/tests/plenary/spec/php_unused_refs_spec.lua
@@ -3,11 +3,11 @@ local php = require('configs.lsp.php')
 local Methods = vim.lsp.protocol.Methods
 local config = php.lspconfigs[1].config
 
--- This spec intentionally reaches into php.lua through named upvalues so it
--- can exercise the real diagnostic helper without widening the runtime API.
--- It is coupled to php.lua's private closure graph, not upvalue order: simple
--- reordering is fine, but refactors that stop capturing these helpers will
--- need to update this test.
+-- This spec intentionally reaches into php.lua through private upvalues so it
+-- can exercise the real diagnostic helpers without widening the runtime API.
+-- It is coupled to php.lua's closure graph. Most lookups are by name, but a
+-- few stable slots are used where PlenaryBustedFile has not been reliable
+-- about exposing the nested helper name during spec load.
 local function get_upvalue(fn, expected_name)
   for index = 1, 20 do
     local name, value = debug.getupvalue(fn, index)
@@ -23,12 +23,24 @@ local function get_upvalue(fn, expected_name)
   error('missing upvalue: ' .. expected_name)
 end
 
+local function get_upvalue_at(fn, index)
+  local _, value = debug.getupvalue(fn, index)
+  if value == nil then
+    error('missing upvalue index: ' .. tostring(index))
+  end
+
+  return value
+end
+
 local schedule_unused_reference_refresh =
   get_upvalue(config.on_attach, 'schedule_unused_reference_refresh')
 local refresh_unused_reference_diagnostics_from_cache =
   get_upvalue(schedule_unused_reference_refresh, 'refresh_unused_reference_diagnostics_from_cache')
+local apply_unused_reference_diagnostics =
+  get_upvalue_at(refresh_unused_reference_diagnostics_from_cache, 6)
 local set_unused_reference_diagnostics =
-  get_upvalue(refresh_unused_reference_diagnostics_from_cache, 'set_unused_reference_diagnostics')
+  get_upvalue_at(apply_unused_reference_diagnostics, 3)
+local unused_refs_states = get_upvalue(config.on_attach, 'unused_refs_states')
 
 local function make_buf(lines)
   local bufnr = vim.api.nvim_create_buf(false, true)
@@ -78,8 +90,10 @@ describe('configs.lsp.php unused reference diagnostics', function()
   local bufnr
   local client
   local requests
+  local resolve_unused_reference_lenses
 
   before_each(function()
+    resolve_unused_reference_lenses = get_upvalue_at(apply_unused_reference_diagnostics, 1)
     requests = { resolve = 0 }
 
     client = {
@@ -89,7 +103,7 @@ describe('configs.lsp.php unused reference diagnostics', function()
     }
 
     function client:supports_method(method)
-      return method == Methods.codeLens_resolve
+      return method == Methods.codeLens_resolve or method == Methods.textDocument_codeLens
     end
 
     function client:request(method, params, callback, target_bufnr)
@@ -106,6 +120,10 @@ describe('configs.lsp.php unused reference diagnostics', function()
   end)
 
   after_each(function()
+    if bufnr then
+      unused_refs_states[bufnr] = nil
+    end
+
     if bufnr and vim.api.nvim_buf_is_valid(bufnr) then
       pcall(vim.api.nvim_buf_delete, bufnr, { force = true })
     end
@@ -143,6 +161,26 @@ describe('configs.lsp.php unused reference diagnostics', function()
     vim.api.nvim_buf_set_lines(bufnr, 1, 1, false, { 'function unused() {}' })
 
     apply_fallback_lenses()
+
+    assert.equals(1, requests.resolve)
+    assert_unused_reference_hint(bufnr)
+  end)
+
+  it('resolves unresolved lenses before applying shared cached diagnostics', function()
+    bufnr = make_buf({
+      '<?php',
+      'function unused() {}',
+      "echo 'ready';",
+    })
+
+    local state = { refresh_seq = 1 }
+    unused_refs_states[bufnr] = state
+
+    resolve_unused_reference_lenses(bufnr, client, state, state.refresh_seq, {
+      unresolved_unused_lens(),
+    }, function(resolved_lenses)
+      set_unused_reference_diagnostics(bufnr, client, resolved_lenses)
+    end)
 
     assert.equals(1, requests.resolve)
     assert_unused_reference_hint(bufnr)

--- a/home/.chezmoitemplates/nvim/tests/plenary/spec/php_unused_refs_spec.lua
+++ b/home/.chezmoitemplates/nvim/tests/plenary/spec/php_unused_refs_spec.lua
@@ -185,4 +185,5 @@ describe('configs.lsp.php unused reference diagnostics', function()
     assert.equals(1, requests.resolve)
     assert_unused_reference_hint(bufnr)
   end)
+
 end)


### PR DESCRIPTION
## Summary
- keep Neovim `0.12` built-in CodeLens as the default path and move custom same-line rendering into `utils.lsp_codelens` for explicit Diffview and `:Gitsigns blame` contexts
- rework PHP Intelephense unused-reference hints to read from the active CodeLens cache first, fall back to a direct request on timeout, resolve unresolved lenses, use encoding-aware columns, and clean up correctly across multi-buffer and detach cases
- tighten Diffview and CodeLens lifecycle handling, remove deprecated/private LSP APIs, unpin `lua-language-server`, and add regression coverage for CodeLens rendering, Diffview sync, and PHP unused-reference diagnostics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Custom per-buffer CodeLens system with a context API and integration for Diffview and blame views.

* **Improvements**
  * Per-buffer PHP CodeLens flow that surfaces "0 References" as hint diagnostics with safer async handling and debounced refreshes.
  * Global coordination with built-in CodeLens and improved diagnostic jump behavior.

* **Chores**
  * Removed explicit version pin for the Lua language server.

* **Tests**
  * Added test suites for CodeLens utilities, Diffview integration, and PHP unused-reference hints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
