### PR TITLE
feat(yazi): add compress/archive plugin

### DIFF
--- a/home/.chezmoitemplates/yazi/keymap.toml
+++ b/home/.chezmoitemplates/yazi/keymap.toml
@@ -100,6 +100,13 @@ keymap = [
 	{ on = [ "c", "f" ], run = "copy filename",         desc = "Copy the filename" },
 	{ on = [ "c", "n" ], run = "copy name_without_ext", desc = "Copy the filename without extension" },
 
+	# Archive
+	{ on = [ "c", "a", "a" ], run = "plugin compress",      desc = "Archive selected files" },
+	{ on = [ "c", "a", "p" ], run = "plugin compress -p",   desc = "Archive selected files (password)" },
+	{ on = [ "c", "a", "h" ], run = "plugin compress -ph",  desc = "Archive selected files (password+header)" },
+	{ on = [ "c", "a", "l" ], run = "plugin compress -l",   desc = "Archive selected files (compression level)" },
+	{ on = [ "c", "a", "u" ], run = "plugin compress -phl", desc = "Archive selected files (password+header+level)" },
+
 	# Filter
 	{ on = "f", run = "filter --smart", desc = "Filter files" },
 

--- a/home/.chezmoitemplates/yazi/package.toml
+++ b/home/.chezmoitemplates/yazi/package.toml
@@ -1,0 +1,7 @@
+[[plugin.deps]]
+use = "KKV9/compress"
+rev = "46a6b9f"
+hash = "771af2becc575a3f43d0542de823969d"
+
+[flavor]
+deps = []

--- a/home/AppData/Roaming/yazi/config/package.toml.tmpl
+++ b/home/AppData/Roaming/yazi/config/package.toml.tmpl
@@ -1,0 +1,1 @@
+{{- template "yazi/package.toml" . -}}

--- a/home/dot_config/yazi/package.toml.tmpl
+++ b/home/dot_config/yazi/package.toml.tmpl
@@ -1,0 +1,1 @@
+{{- template "yazi/package.toml" . -}}


### PR DESCRIPTION
## Summary
- Add [KKV9/compress](https://github.com/KKV9/compress) plugin for archive/extract operations in yazi
- Bind archive operations under `c+a` keymap prefix: plain, password, header encryption, compression level, and full combo
- Cross-platform via shared chezmoi template (Linux `dot_config` + Windows `AppData`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added archive creation functionality with support for password protection, combined password and header encryption, and customizable compression levels.

* **Chores**
  * Added plugin dependency to support archive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->