### PR TITLE
feat(nvim): switch claudecode diff to vertical split layout

### DIFF
--- a/home/.shared-configs/nvim/lua/plugins/claudecode.lua
+++ b/home/.shared-configs/nvim/lua/plugins/claudecode.lua
@@ -17,7 +17,10 @@ return {
       },
     },
     diff_opts = {
-      open_in_current_tab = true,
+      layout = 'vertical', -- "vertical" or "horizontal"
+      open_in_new_tab = true,
+      keep_terminal_focus = false,
+      hide_terminal_in_new_tab = true,
     },
   },
   config = true,


### PR DESCRIPTION
## Summary
- Replace `open_in_current_tab` diff mode with vertical split layout (`layout = 'vertical'`)
- Open diffs in new tab with terminal hidden for focused multi-file review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated diff viewer configuration for the Neovim code assistant plugin to open diffs in new tabs with a vertical layout, preventing terminal focus shifts and hiding the terminal window in the new tab for improved diff viewing experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->