### PR TITLE
feat(workmux): add workmux config and smug worktree workflow

### DIFF
--- a/.workmux.yaml
+++ b/.workmux.yaml
@@ -1,6 +1,10 @@
 main_branch: main
 worktree_dir: worktrees
-window_prefix: ""
+
+files:
+  symlink:
+    - .env
+    - node_modules
 
 panes:
   - command: nvim

--- a/.workmux.yaml
+++ b/.workmux.yaml
@@ -1,0 +1,7 @@
+main_branch: main
+worktree_dir: worktrees
+window_prefix: ""
+
+panes:
+  - command: nvim
+    focus: true

--- a/home/dot_config/smug/dotfiles.yml
+++ b/home/dot_config/smug/dotfiles.yml
@@ -3,15 +3,10 @@ root: ~/.local/share/chezmoi
 attach: true
 
 windows:
-  - name: root
+  - name: workmux
     selected: true
     commands:
-      - nvim
-  - name: nvim
-    root: home/.shared-configs/nvim
-    commands:
-      - nvim
-  - name: wezterm
-    root: home/dot_config/wezterm
+      - workmux dashboard --session --tab worktrees
+  - name: main
     commands:
       - nvim


### PR DESCRIPTION
## Summary

- Add `.workmux.yaml` with minimal v0 config: single `nvim` pane, symlinks for `.env` and `node_modules`
- Replace fixed smug windows (`root`/`nvim`/`wezterm`) with `workmux` dashboard + `main` editor layout
- Worktree symlinks ensure MCP API keys and build tooling are available in clean checkouts

## Workflow

1. `smug start dotfiles` opens dashboard + main nvim
2. `workmux add <topic>` creates worktree + tmux window with nvim
3. Start agents manually inside nvim (`<leader>ac`, `<leader>oc`, `<leader>cc`)
4. `workmux merge` or `workmux remove` to clean up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new `.workmux.yaml` configuration file with settings for branch management and symlink configuration
  * Reorganized development environment window setup by updating the smug configuration file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->