### PR TITLE
refactor(nvim): migrate markdown LSP from marksman to markdown-oxide

### DIFF
--- a/home/.shared-configs/nvim/lua/configs/lsp/markdown.lua
+++ b/home/.shared-configs/nvim/lua/configs/lsp/markdown.lua
@@ -1,32 +1,27 @@
 local LanguageSetting = require('configs.lsp.base')
 local LspConfig = require('configs.lsp.lspconfig')
-local obsidian = require('utils.obsidian')
 local M = LanguageSetting:new()
 
 M.treesitter.filetypes = { 'markdown', 'markdown_inline' }
 
----@param client vim.lsp.Client
-local function restrict_marksman_to_hover_only(client)
-  if not client.server_capabilities then
-    return
-  end
-
-  local hover_provider = client.server_capabilities.hoverProvider
-
-  client.server_capabilities = {}
-
-  client.server_capabilities.hoverProvider = hover_provider
-end
-
-local marksman = LspConfig:new('marksman', 'marksman')
-marksman.config = {
-  on_attach = function(client, bufnr)
-    if obsidian.is_vault(bufnr) then
-      restrict_marksman_to_hover_only(client)
-    end
-  end,
+local capabilities = {
+  workspace = {
+    didChangeWatchedFiles = {
+      dynamicRegistration = true,
+    },
+  },
 }
 
-M.lspconfigs = { marksman }
+local ok, blink = pcall(require, 'blink.cmp')
+if ok then
+  capabilities = blink.get_lsp_capabilities(capabilities)
+end
+
+local markdown_oxide = LspConfig:new('markdown_oxide', 'markdown-oxide')
+markdown_oxide.config = {
+  capabilities = capabilities,
+}
+
+M.lspconfigs = { markdown_oxide }
 
 return M

--- a/home/.shared-configs/nvim/lua/configs/lsp/markdown.lua
+++ b/home/.shared-configs/nvim/lua/configs/lsp/markdown.lua
@@ -4,13 +4,13 @@ local M = LanguageSetting:new()
 
 M.treesitter.filetypes = { 'markdown', 'markdown_inline' }
 
-local capabilities = {
+local capabilities = vim.tbl_deep_extend('force', vim.lsp.protocol.make_client_capabilities(), {
   workspace = {
     didChangeWatchedFiles = {
       dynamicRegistration = true,
     },
   },
-}
+})
 
 local ok, blink = pcall(require, 'blink.cmp')
 if ok then

--- a/home/.shared-configs/nvim/lua/plugins/obsidian.lua
+++ b/home/.shared-configs/nvim/lua/plugins/obsidian.lua
@@ -29,6 +29,7 @@ return {
         end,
       },
     },
+    completion = { nvim_cmp = false, blink = false },
     picker = {
       name = 'snacks.pick',
     },


### PR DESCRIPTION
## Summary
- Replace **marksman** with **markdown-oxide** as the markdown LSP server
- Remove obsidian vault hover-only workaround — markdown-oxide handles PKM/obsidian natively
- Disable obsidian.nvim built-in completion to avoid duplicate sources with markdown-oxide LSP completion

## Changes
- `markdown.lua`: remove marksman config + vault restriction hack; add markdown-oxide with file watcher capabilities and blink.cmp integration
- `obsidian.lua`: disable `nvim_cmp` and `blink` completion sources

## Test plan
- [x] Open a markdown file outside an obsidian vault — LSP completion, hover, diagnostics work
- [x] Open a markdown file inside an obsidian vault — LSP features work without conflicts with obsidian.nvim
- [x] Verify blink.cmp provides markdown completions via LSP

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Switched the markdown language server to markdown_oxide for improved Markdown support.

* **Changes**
  * Improved LSP capabilities to better handle file-watching and optional completion enhancements when available.
  * Removed Obsidian-specific runtime restrictions that limited markdown features.
  * Disabled external completion integrations for the Obsidian plugin to avoid conflicts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->