### PR TITLE
feat(worktree): worktree-aware chezmoi dev commands 

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,11 @@
     "build:notify": "bun build --compile scripts/agent-notify.ts --outfile ~/.local/bin/agent-notify",
     "reconcile:configs": "bun run scripts/reconcile-configs.ts",
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "worktree:context": "bun run scripts/worktree-dev.ts context",
+    "worktree:diff": "bun run scripts/worktree-dev.ts diff",
+    "worktree:dry-run": "bun run scripts/worktree-dev.ts dry-run",
+    "worktree:apply-temp": "bun run scripts/worktree-dev.ts apply-temp"
   },
   "devDependencies": {
     "@types/bun": "latest",

--- a/scripts/chezmoi-paths.ts
+++ b/scripts/chezmoi-paths.ts
@@ -1,0 +1,145 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { parseArgs } from "node:util";
+
+const defaultSourceRoot = "home";
+
+export type PathOverrides = {
+  sourceDir?: string;
+  workingTree?: string;
+};
+
+export type BasePathOptions = {
+  repoRoot?: string;
+  sourceStateRoot?: string;
+};
+
+export function tokenizeShellWords(
+  value: string,
+  options: { preserveBackslashes?: boolean } = {},
+): string[] {
+  const tokens: string[] = [];
+  let current = "";
+  let quote: '"' | "'" | null = null;
+
+  function pushCurrent(): void {
+    if (current.length > 0) {
+      tokens.push(current);
+      current = "";
+    }
+  }
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value.charAt(index);
+
+    if (quote === null) {
+      if (/\s/.test(character)) {
+        pushCurrent();
+        continue;
+      }
+
+      if (character === '"' || character === "'") {
+        quote = character;
+        continue;
+      }
+
+      if (character === "\\") {
+        if (index + 1 < value.length) {
+          const nextCharacter = value.charAt(index + 1);
+          if (
+            !options.preserveBackslashes ||
+            nextCharacter === "\\" ||
+            nextCharacter === '"' ||
+            nextCharacter === "'" ||
+            /\s/.test(nextCharacter)
+          ) {
+            current += nextCharacter;
+            index += 1;
+            continue;
+          }
+        }
+
+        current += character;
+        continue;
+      }
+
+      current += character;
+      continue;
+    }
+
+    if (character === quote) {
+      quote = null;
+      continue;
+    }
+
+    if (character === "\\" && quote === '"') {
+      if (index + 1 < value.length) {
+        const nextCharacter = value.charAt(index + 1);
+        if (
+          !options.preserveBackslashes ||
+          nextCharacter === "\\" ||
+          nextCharacter === '"' ||
+          nextCharacter === "$" ||
+          nextCharacter === "`"
+        ) {
+          current += nextCharacter;
+          index += 1;
+          continue;
+        }
+      }
+
+      current += character;
+      continue;
+    }
+
+    current += character;
+  }
+
+  pushCurrent();
+  return tokens;
+}
+
+export function resolvePathOverrides(rawChezMoiArgs: string): PathOverrides {
+  const { values } = parseArgs({
+    args: tokenizeShellWords(rawChezMoiArgs, { preserveBackslashes: true }),
+    options: {
+      source: { type: "string", short: "S" },
+      "working-tree": { type: "string", short: "W" },
+    },
+    strict: false,
+    allowPositionals: true,
+  });
+
+  return {
+    sourceDir: values.source as string | undefined,
+    workingTree: values["working-tree"] as string | undefined,
+  };
+}
+
+export function resolveSourceStateRoot(repoRoot: string): string {
+  try {
+    const configuredRoot = readFileSync(path.join(repoRoot, ".chezmoiroot"), "utf8").trim();
+    return path.join(repoRoot, configuredRoot || defaultSourceRoot);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+
+    return path.join(repoRoot, defaultSourceRoot);
+  }
+}
+
+export function resolveBasePaths(
+  options: BasePathOptions,
+  defaultRepoRoot: string,
+  rawChezMoiArgs: string = process.env.CHEZMOI_ARGS ?? "",
+): { repoRoot: string; sourceStateRoot: string } {
+  const pathOverrides = resolvePathOverrides(rawChezMoiArgs);
+  const repoRoot = options.repoRoot ?? pathOverrides.workingTree ?? defaultRepoRoot;
+
+  return {
+    repoRoot,
+    sourceStateRoot:
+      options.sourceStateRoot ?? pathOverrides.sourceDir ?? resolveSourceStateRoot(repoRoot),
+  };
+}

--- a/scripts/chezmoi-paths.ts
+++ b/scripts/chezmoi-paths.ts
@@ -21,11 +21,13 @@ export function tokenizeShellWords(
   const tokens: string[] = [];
   let current = "";
   let quote: '"' | "'" | null = null;
+  let tokenWasQuoted = false;
 
   function pushCurrent(): void {
-    if (current.length > 0) {
+    if (current.length > 0 || tokenWasQuoted) {
       tokens.push(current);
       current = "";
+      tokenWasQuoted = false;
     }
   }
 
@@ -40,6 +42,7 @@ export function tokenizeShellWords(
 
       if (character === '"' || character === "'") {
         quote = character;
+        tokenWasQuoted = true;
         continue;
       }
 

--- a/scripts/reconcile-configs.test.ts
+++ b/scripts/reconcile-configs.test.ts
@@ -281,6 +281,24 @@ describe("resolvePathOverrides", () => {
     });
   });
 
+  test("preserves quoted empty values", () => {
+    expect(tokenizeShellWords(`chezmoi apply --source "" -W /tmp/worktree`)).toEqual([
+      "chezmoi",
+      "apply",
+      "--source",
+      "",
+      "-W",
+      "/tmp/worktree",
+    ]);
+  });
+
+  test("keeps empty quoted source override from consuming next flag", () => {
+    expect(resolvePathOverrides(`chezmoi apply --source "" -W /tmp/worktree`)).toEqual({
+      sourceDir: "",
+      workingTree: "/tmp/worktree",
+    });
+  });
+
   test("returns empty overrides for empty args", () => {
     expect(resolvePathOverrides("")).toEqual({
       sourceDir: undefined,

--- a/scripts/reconcile-configs.test.ts
+++ b/scripts/reconcile-configs.test.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import {
   reconcileAllTools,
   reconcileTool,
+  resolveBasePaths,
   resolveLogMode,
   resolvePathOverrides,
   runCli,
@@ -269,10 +270,34 @@ describe("resolvePathOverrides", () => {
     });
   });
 
+  test("preserves backslashes in quoted Windows paths", () => {
+    expect(
+      resolvePathOverrides(
+        String.raw`chezmoi apply -S "C:\Users\me\repo\home" -W "C:\Users\me\repo"`,
+      ),
+    ).toEqual({
+      sourceDir: String.raw`C:\Users\me\repo\home`,
+      workingTree: String.raw`C:\Users\me\repo`,
+    });
+  });
+
   test("returns empty overrides for empty args", () => {
     expect(resolvePathOverrides("")).toEqual({
       sourceDir: undefined,
       workingTree: undefined,
+    });
+  });
+});
+
+describe("resolveBasePaths", () => {
+  test("falls back to .chezmoiroot when no overrides are present", async () => {
+    const repoRoot = await fs.mkdtemp(path.join(os.tmpdir(), "chezmoi-paths-test-"));
+    tempDirs.push(repoRoot);
+    await fs.writeFile(path.join(repoRoot, ".chezmoiroot"), "dotfiles\n", "utf8");
+
+    expect(resolveBasePaths({}, repoRoot, "")).toEqual({
+      repoRoot,
+      sourceStateRoot: path.join(repoRoot, "dotfiles"),
     });
   });
 });

--- a/scripts/reconcile-configs.test.ts
+++ b/scripts/reconcile-configs.test.ts
@@ -7,6 +7,7 @@ import {
   reconcileAllTools,
   reconcileTool,
   resolveLogMode,
+  resolvePathOverrides,
   runCli,
   tokenizeShellWords,
   type LogMode,
@@ -196,6 +197,83 @@ describe("log mode helpers", () => {
     expect(resolveLogMode(`chezmoi apply --source="/tmp/my --debug repo"`)).toBe(
       "info",
     );
+  });
+});
+
+describe("resolvePathOverrides", () => {
+  test("returns empty overrides when no path flags are present", () => {
+    expect(resolvePathOverrides("chezmoi apply -v")).toEqual({
+      sourceDir: undefined,
+      workingTree: undefined,
+    });
+  });
+
+  test("resolves --source to sourceDir", () => {
+    expect(resolvePathOverrides("chezmoi apply --source /tmp/worktree/home")).toEqual({
+      sourceDir: "/tmp/worktree/home",
+      workingTree: undefined,
+    });
+  });
+
+  test("resolves -S short flag to sourceDir", () => {
+    expect(resolvePathOverrides("chezmoi apply -S /tmp/worktree/home")).toEqual({
+      sourceDir: "/tmp/worktree/home",
+      workingTree: undefined,
+    });
+  });
+
+  test("resolves --working-tree to workingTree", () => {
+    expect(resolvePathOverrides("chezmoi apply --working-tree /tmp/worktree")).toEqual({
+      sourceDir: undefined,
+      workingTree: "/tmp/worktree",
+    });
+  });
+
+  test("resolves -W short flag to workingTree", () => {
+    expect(resolvePathOverrides("chezmoi apply -W /tmp/worktree")).toEqual({
+      sourceDir: undefined,
+      workingTree: "/tmp/worktree",
+    });
+  });
+
+  test("resolves both flags together", () => {
+    expect(
+      resolvePathOverrides(
+        "chezmoi apply -S /tmp/worktree/home -W /tmp/worktree",
+      ),
+    ).toEqual({
+      sourceDir: "/tmp/worktree/home",
+      workingTree: "/tmp/worktree",
+    });
+  });
+
+  test("resolves long flags together with extra flags", () => {
+    expect(
+      resolvePathOverrides(
+        "chezmoi diff --init --source /wt/home --working-tree /wt -v",
+      ),
+    ).toEqual({
+      sourceDir: "/wt/home",
+      workingTree: "/wt",
+    });
+  });
+
+  test("handles quoted paths with spaces", () => {
+    expect(
+      resolvePathOverrides(
+        `chezmoi apply -S "/tmp/my worktree/home" -W "/tmp/my worktree"`,
+      ),
+    ).toEqual({
+      sourceDir: "/tmp/my worktree/home",
+      workingTree: "/tmp/my worktree",
+    });
+  });
+
+  test("returns empty overrides for empty args", () => {
+    expect(resolvePathOverrides("")).toEqual({
+      sourceDir: undefined,
+      workingTree: undefined,
+    });
   });
 });
 

--- a/scripts/reconcile-configs.ts
+++ b/scripts/reconcile-configs.ts
@@ -4,7 +4,19 @@ import os from "node:os";
 import path from "node:path";
 import { parseArgs } from "node:util";
 
+import {
+  resolveBasePaths,
+  resolvePathOverrides,
+  tokenizeShellWords,
+} from "./chezmoi-paths.ts";
 import { type ToolConfig, tools as defaultTools, validateToolRegistry } from "./tools.config.ts";
+
+export {
+  resolveBasePaths,
+  resolvePathOverrides,
+  tokenizeShellWords,
+} from "./chezmoi-paths.ts";
+export type { PathOverrides } from "./chezmoi-paths.ts";
 
 export type PlatformKind = "unix" | "windows";
 export type LogMode = "info" | "verbose" | "debug";
@@ -58,28 +70,6 @@ type LogWriters = {
   now: () => Date;
 };
 
-export type PathOverrides = {
-  sourceDir?: string;
-  workingTree?: string;
-};
-
-export function resolvePathOverrides(rawChezMoiArgs: string): PathOverrides {
-  const { values } = parseArgs({
-    args: tokenizeShellWords(rawChezMoiArgs),
-    options: {
-      source: { type: "string", short: "S" },
-      "working-tree": { type: "string", short: "W" },
-    },
-    strict: false,
-    allowPositionals: true,
-  });
-
-  return {
-    sourceDir: values.source as string | undefined,
-    workingTree: values["working-tree"] as string | undefined,
-  };
-}
-
 export type ReconcileOptions = {
   hostHome?: string;
   hostKind?: PlatformKind;
@@ -114,66 +104,6 @@ const allFilesGlob = new Glob("**/*");
 const wrapperFilesGlob = new Glob("**/*.tmpl");
 const defaultRepoRoot = path.resolve(import.meta.dir, "..");
 const defaultHostKind: PlatformKind = process.platform === "win32" ? "windows" : "unix";
-
-export function tokenizeShellWords(value: string): string[] {
-  const tokens: string[] = [];
-  let current = "";
-  let quote: '"' | "'" | null = null;
-
-  function pushCurrent(): void {
-    if (current.length > 0) {
-      tokens.push(current);
-      current = "";
-    }
-  }
-
-  for (let index = 0; index < value.length; index += 1) {
-    const character = value.charAt(index);
-
-    if (quote === null) {
-      if (/\s/.test(character)) {
-        pushCurrent();
-        continue;
-      }
-
-      if (character === '"' || character === "'") {
-        quote = character;
-        continue;
-      }
-
-      if (character === "\\") {
-        if (index + 1 < value.length) {
-          const nextCharacter = value.charAt(index + 1);
-          current += nextCharacter;
-          index += 1;
-          continue;
-        }
-      }
-
-      current += character;
-      continue;
-    }
-
-    if (character === quote) {
-      quote = null;
-      continue;
-    }
-
-    if (character === "\\" && quote === '"') {
-      if (index + 1 < value.length) {
-        const nextCharacter = value.charAt(index + 1);
-        current += nextCharacter;
-        index += 1;
-        continue;
-      }
-    }
-
-    current += character;
-  }
-
-  pushCurrent();
-  return tokens;
-}
 
 export function resolveLogMode(rawChezMoiArgs: string): LogMode {
   const { values } = parseArgs({
@@ -260,9 +190,7 @@ function createLogger(logPrefix: string, logMode: LogMode, writers: LogWriters):
 }
 
 function createRuntime(tool: ToolConfig, options: ReconcileOptions = {}): ReconcileRuntime {
-  const pathOverrides = resolvePathOverrides(process.env.CHEZMOI_ARGS ?? "");
-  const repoRoot = options.repoRoot ?? pathOverrides.workingTree ?? defaultRepoRoot;
-  const sourceStateRoot = options.sourceStateRoot ?? pathOverrides.sourceDir ?? path.join(repoRoot, "home");
+  const { repoRoot, sourceStateRoot } = resolveBasePaths(options, defaultRepoRoot);
   const hostHome = options.hostHome ?? os.homedir();
   const hostKind = options.hostKind ?? defaultHostKind;
   const logMode = options.logMode ?? resolveLogMode(process.env.CHEZMOI_ARGS ?? "");
@@ -721,9 +649,7 @@ export async function reconcileAllTools(
     }
   }
 
-  const pathOverrides = resolvePathOverrides(process.env.CHEZMOI_ARGS ?? "");
-  const repoRoot = options.repoRoot ?? pathOverrides.workingTree ?? defaultRepoRoot;
-  const sourceStateRoot = options.sourceStateRoot ?? pathOverrides.sourceDir ?? path.join(repoRoot, "home");
+  const { repoRoot, sourceStateRoot } = resolveBasePaths(options, defaultRepoRoot);
   const removeManifestPath = options.removeManifestPath ?? path.join(sourceStateRoot, ".chezmoiremove");
   const logMode = options.logMode ?? resolveLogMode(process.env.CHEZMOI_ARGS ?? "");
   const writers: LogWriters = {

--- a/scripts/reconcile-configs.ts
+++ b/scripts/reconcile-configs.ts
@@ -58,6 +58,28 @@ type LogWriters = {
   now: () => Date;
 };
 
+export type PathOverrides = {
+  sourceDir?: string;
+  workingTree?: string;
+};
+
+export function resolvePathOverrides(rawChezMoiArgs: string): PathOverrides {
+  const { values } = parseArgs({
+    args: tokenizeShellWords(rawChezMoiArgs),
+    options: {
+      source: { type: "string", short: "S" },
+      "working-tree": { type: "string", short: "W" },
+    },
+    strict: false,
+    allowPositionals: true,
+  });
+
+  return {
+    sourceDir: values.source as string | undefined,
+    workingTree: values["working-tree"] as string | undefined,
+  };
+}
+
 export type ReconcileOptions = {
   hostHome?: string;
   hostKind?: PlatformKind;
@@ -238,8 +260,9 @@ function createLogger(logPrefix: string, logMode: LogMode, writers: LogWriters):
 }
 
 function createRuntime(tool: ToolConfig, options: ReconcileOptions = {}): ReconcileRuntime {
-  const repoRoot = options.repoRoot ?? defaultRepoRoot;
-  const sourceStateRoot = options.sourceStateRoot ?? path.join(repoRoot, "home");
+  const pathOverrides = resolvePathOverrides(process.env.CHEZMOI_ARGS ?? "");
+  const repoRoot = options.repoRoot ?? pathOverrides.workingTree ?? defaultRepoRoot;
+  const sourceStateRoot = options.sourceStateRoot ?? pathOverrides.sourceDir ?? path.join(repoRoot, "home");
   const hostHome = options.hostHome ?? os.homedir();
   const hostKind = options.hostKind ?? defaultHostKind;
   const logMode = options.logMode ?? resolveLogMode(process.env.CHEZMOI_ARGS ?? "");
@@ -698,8 +721,9 @@ export async function reconcileAllTools(
     }
   }
 
-  const repoRoot = options.repoRoot ?? defaultRepoRoot;
-  const sourceStateRoot = options.sourceStateRoot ?? path.join(repoRoot, "home");
+  const pathOverrides = resolvePathOverrides(process.env.CHEZMOI_ARGS ?? "");
+  const repoRoot = options.repoRoot ?? pathOverrides.workingTree ?? defaultRepoRoot;
+  const sourceStateRoot = options.sourceStateRoot ?? pathOverrides.sourceDir ?? path.join(repoRoot, "home");
   const removeManifestPath = options.removeManifestPath ?? path.join(sourceStateRoot, ".chezmoiremove");
   const logMode = options.logMode ?? resolveLogMode(process.env.CHEZMOI_ARGS ?? "");
   const writers: LogWriters = {

--- a/scripts/worktree-dev.test.ts
+++ b/scripts/worktree-dev.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { parseCliArgs } from "./worktree-dev.ts";
+
+describe("parseCliArgs", () => {
+  test("parses command positional", () => {
+    expect(parseCliArgs(["context"])).toEqual({
+      command: "context",
+      help: false,
+    });
+  });
+
+  test("parses help flag", () => {
+    expect(parseCliArgs(["--help"])).toEqual({
+      command: undefined,
+      help: true,
+    });
+  });
+
+  test("parses short help flag with command", () => {
+    expect(parseCliArgs(["-h", "diff"])).toEqual({
+      command: "diff",
+      help: true,
+    });
+  });
+});

--- a/scripts/worktree-dev.test.ts
+++ b/scripts/worktree-dev.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 
-import { parseCliArgs } from "./worktree-dev.ts";
+import { handleSpawnResult, ParseCliError, parseCliArgs } from "./worktree-dev.ts";
 
 describe("parseCliArgs", () => {
   test("parses command positional", () => {
@@ -22,5 +22,41 @@ describe("parseCliArgs", () => {
       command: "diff",
       help: true,
     });
+  });
+
+  test("throws ParseCliError for unknown commands", () => {
+    try {
+      parseCliArgs(["nope"]);
+      throw new Error("expected parseCliArgs to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ParseCliError);
+      expect((error as Error).message).toContain("unknown command: nope");
+      expect((error as Error).message).toContain("[--help|-h]");
+    }
+  });
+
+  test("throws ParseCliError for too many positionals", () => {
+    try {
+      parseCliArgs(["context", "diff"]);
+      throw new Error("expected parseCliArgs to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(ParseCliError);
+      expect((error as Error).message).toContain("expected exactly one command");
+    }
+  });
+
+  test("re-raises child signals instead of converting them to exit code 1", () => {
+    const calls: string[] = [];
+
+    handleSpawnResult(
+      { signal: "SIGTERM", status: null },
+      {
+        fail: (message) => calls.push(`fail:${message}`),
+        exit: (code) => calls.push(`exit:${code}`),
+        raiseSignal: (signal) => calls.push(`signal:${signal}`),
+      },
+    );
+
+    expect(calls).toEqual(["signal:SIGTERM"]);
   });
 });

--- a/scripts/worktree-dev.ts
+++ b/scripts/worktree-dev.ts
@@ -1,0 +1,90 @@
+import { spawnSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const commands = ["context", "diff", "dry-run", "apply-temp"] as const;
+
+type WorktreeCommand = (typeof commands)[number];
+
+function fail(message: string): never {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function resolveWorktreeRoot(): string {
+  const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+
+  if (result.error) {
+    fail(`failed to run git: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    fail(result.stderr.trim() || "failed to resolve git worktree root");
+  }
+
+  const worktree = result.stdout.trim();
+  if (!worktree) {
+    fail("git returned an empty worktree root");
+  }
+
+  return worktree;
+}
+
+function commonArgs(worktree: string): string[] {
+  return ["--init", "-S", path.join(worktree, "home"), "-W", worktree];
+}
+
+function chezmoiCommandArgs(command: WorktreeCommand, worktree: string): string[] {
+  const baseArgs = commonArgs(worktree);
+
+  switch (command) {
+    case "context":
+      return [
+        "execute-template",
+        ...baseArgs,
+        "{{ .chezmoi.workingTree }}|{{ .chezmoi.sourceDir }}",
+      ];
+    case "diff":
+      return ["diff", ...baseArgs];
+    case "dry-run":
+      return ["apply", ...baseArgs, "-n", "-v"];
+    case "apply-temp": {
+      const destDir = mkdtempSync(path.join(os.tmpdir(), "chezmoi-worktree-"));
+      process.stderr.write(`temporary destination: ${destDir}\n`);
+      return ["apply", ...baseArgs, "-v", "-D", destDir];
+    }
+  }
+}
+
+function parseCommand(value: string | undefined): WorktreeCommand {
+  if (value === undefined) {
+    fail(`usage: bun run scripts/worktree-dev.ts <${commands.join("|")}>`);
+  }
+
+  if ((commands as readonly string[]).includes(value)) {
+    return value as WorktreeCommand;
+  }
+
+  fail(`unknown command: ${value}`);
+}
+
+function main(): void {
+  const command = parseCommand(process.argv[2]);
+  const worktree = resolveWorktreeRoot();
+  const result = spawnSync("chezmoi", chezmoiCommandArgs(command, worktree), {
+    cwd: process.cwd(),
+    stdio: "inherit",
+  });
+
+  if (result.error) {
+    fail(`failed to run chezmoi: ${result.error.message}`);
+  }
+
+  process.exit(result.status ?? 1);
+}
+
+main();

--- a/scripts/worktree-dev.ts
+++ b/scripts/worktree-dev.ts
@@ -103,7 +103,14 @@ const commandArgs: Record<WorktreeCommand, (worktree: string) => string[]> = {
   diff: (worktree) => ["diff", ...commonArgs(worktree)],
   "dry-run": (worktree) => ["apply", ...commonArgs(worktree), "-n", "-v"],
   "apply-temp": (worktree) => {
-    const destDir = mkdtempSync(path.join(os.tmpdir(), "chezmoi-worktree-"));
+    let destDir: string;
+
+    try {
+      destDir = mkdtempSync(path.join(os.tmpdir(), "chezmoi-worktree-"));
+    } catch (error) {
+      fail(error instanceof Error ? error.message : String(error));
+    }
+
     process.stderr.write(`temporary destination: ${destDir}\n`);
     return ["apply", ...commonArgs(worktree), "-v", "-D", destDir];
   },

--- a/scripts/worktree-dev.ts
+++ b/scripts/worktree-dev.ts
@@ -4,13 +4,34 @@ import os from "node:os";
 import path from "node:path";
 import { parseArgs } from "node:util";
 
+import { resolveSourceStateRoot } from "./chezmoi-paths.ts";
+
 const commands = ["context", "diff", "dry-run", "apply-temp"] as const;
-const usage = `usage: bun run scripts/worktree-dev.ts [--help] <${commands.join("|")}>`;
+const usage = `usage: bun run scripts/worktree-dev.ts [--help|-h] <${commands.join("|")}>`;
 
 export type WorktreeCommand = (typeof commands)[number];
 export type ParsedCliArgs = {
   command?: WorktreeCommand;
   help: boolean;
+};
+
+export class ParseCliError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ParseCliError";
+  }
+}
+
+type SpawnResult = {
+  error?: Error;
+  signal?: NodeJS.Signals | null;
+  status?: number | null;
+};
+
+type SpawnResultHandlers = {
+  fail: (message: string) => void;
+  exit: (code: number) => void;
+  raiseSignal: (signal: NodeJS.Signals) => void;
 };
 
 function fail(message: string): never {
@@ -20,6 +41,31 @@ function fail(message: string): never {
 
 function writeUsage(): void {
   process.stdout.write(`${usage}\n`);
+}
+
+function usageError(message: string): ParseCliError {
+  return new ParseCliError(`${message}\n${usage}`);
+}
+
+export function handleSpawnResult(
+  result: SpawnResult,
+  handlers: SpawnResultHandlers = {
+    fail,
+    exit: (code) => process.exit(code),
+    raiseSignal: (signal) => process.kill(process.pid, signal),
+  },
+): void {
+  if (result.error) {
+    handlers.fail(`failed to run chezmoi: ${result.error.message}`);
+    return;
+  }
+
+  if (result.signal) {
+    handlers.raiseSignal(result.signal);
+    return;
+  }
+
+  handlers.exit(result.status ?? 1);
 }
 
 function resolveWorktreeRoot(): string {
@@ -45,7 +91,7 @@ function resolveWorktreeRoot(): string {
 }
 
 function commonArgs(worktree: string): string[] {
-  return ["--init", "-S", path.join(worktree, "home"), "-W", worktree];
+  return ["--init", "-S", resolveSourceStateRoot(worktree), "-W", worktree];
 }
 
 const commandArgs: Record<WorktreeCommand, (worktree: string) => string[]> = {
@@ -72,7 +118,7 @@ function parseCommand(value: string | undefined): WorktreeCommand | undefined {
     return value as WorktreeCommand;
   }
 
-  fail(`unknown command: ${value}\n${usage}`);
+  throw usageError(`unknown command: ${value}`);
 }
 
 export function parseCliArgs(args: string[]): ParsedCliArgs {
@@ -89,11 +135,11 @@ export function parseCliArgs(args: string[]): ParsedCliArgs {
     }));
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
-    fail(`${message}\n${usage}`);
+    throw usageError(message);
   }
 
   if (positionals.length > 1) {
-    fail(`expected exactly one command\n${usage}`);
+    throw usageError("expected exactly one command");
   }
 
   return {
@@ -103,7 +149,18 @@ export function parseCliArgs(args: string[]): ParsedCliArgs {
 }
 
 function main(): void {
-  const parsed = parseCliArgs(process.argv.slice(2));
+  let parsed: ParsedCliArgs;
+
+  try {
+    parsed = parseCliArgs(process.argv.slice(2));
+  } catch (error) {
+    if (error instanceof ParseCliError) {
+      fail(error.message);
+    }
+
+    throw error;
+  }
+
   if (parsed.help) {
     writeUsage();
     process.exit(0);
@@ -118,12 +175,7 @@ function main(): void {
     cwd: process.cwd(),
     stdio: "inherit",
   });
-
-  if (result.error) {
-    fail(`failed to run chezmoi: ${result.error.message}`);
-  }
-
-  process.exit(result.status ?? 1);
+  handleSpawnResult(result);
 }
 
 if (import.meta.main) {

--- a/scripts/worktree-dev.ts
+++ b/scripts/worktree-dev.ts
@@ -2,14 +2,24 @@ import { spawnSync } from "node:child_process";
 import { mkdtempSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
+import { parseArgs } from "node:util";
 
 const commands = ["context", "diff", "dry-run", "apply-temp"] as const;
+const usage = `usage: bun run scripts/worktree-dev.ts [--help] <${commands.join("|")}>`;
 
-type WorktreeCommand = (typeof commands)[number];
+export type WorktreeCommand = (typeof commands)[number];
+export type ParsedCliArgs = {
+  command?: WorktreeCommand;
+  help: boolean;
+};
 
 function fail(message: string): never {
   process.stderr.write(`${message}\n`);
   process.exit(1);
+}
+
+function writeUsage(): void {
+  process.stdout.write(`${usage}\n`);
 }
 
 function resolveWorktreeRoot(): string {
@@ -38,44 +48,73 @@ function commonArgs(worktree: string): string[] {
   return ["--init", "-S", path.join(worktree, "home"), "-W", worktree];
 }
 
-function chezmoiCommandArgs(command: WorktreeCommand, worktree: string): string[] {
-  const baseArgs = commonArgs(worktree);
+const commandArgs: Record<WorktreeCommand, (worktree: string) => string[]> = {
+  context: (worktree) => [
+    "execute-template",
+    ...commonArgs(worktree),
+    "{{ .chezmoi.workingTree }}|{{ .chezmoi.sourceDir }}",
+  ],
+  diff: (worktree) => ["diff", ...commonArgs(worktree)],
+  "dry-run": (worktree) => ["apply", ...commonArgs(worktree), "-n", "-v"],
+  "apply-temp": (worktree) => {
+    const destDir = mkdtempSync(path.join(os.tmpdir(), "chezmoi-worktree-"));
+    process.stderr.write(`temporary destination: ${destDir}\n`);
+    return ["apply", ...commonArgs(worktree), "-v", "-D", destDir];
+  },
+};
 
-  switch (command) {
-    case "context":
-      return [
-        "execute-template",
-        ...baseArgs,
-        "{{ .chezmoi.workingTree }}|{{ .chezmoi.sourceDir }}",
-      ];
-    case "diff":
-      return ["diff", ...baseArgs];
-    case "dry-run":
-      return ["apply", ...baseArgs, "-n", "-v"];
-    case "apply-temp": {
-      const destDir = mkdtempSync(path.join(os.tmpdir(), "chezmoi-worktree-"));
-      process.stderr.write(`temporary destination: ${destDir}\n`);
-      return ["apply", ...baseArgs, "-v", "-D", destDir];
-    }
-  }
-}
-
-function parseCommand(value: string | undefined): WorktreeCommand {
+function parseCommand(value: string | undefined): WorktreeCommand | undefined {
   if (value === undefined) {
-    fail(`usage: bun run scripts/worktree-dev.ts <${commands.join("|")}>`);
+    return undefined;
   }
 
-  if ((commands as readonly string[]).includes(value)) {
+  if (Object.hasOwn(commandArgs, value)) {
     return value as WorktreeCommand;
   }
 
-  fail(`unknown command: ${value}`);
+  fail(`unknown command: ${value}\n${usage}`);
+}
+
+export function parseCliArgs(args: string[]): ParsedCliArgs {
+  let values: { help?: boolean };
+  let positionals: string[];
+
+  try {
+    ({ values, positionals } = parseArgs({
+      args,
+      options: {
+        help: { type: "boolean", short: "h", default: false },
+      },
+      allowPositionals: true,
+    }));
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    fail(`${message}\n${usage}`);
+  }
+
+  if (positionals.length > 1) {
+    fail(`expected exactly one command\n${usage}`);
+  }
+
+  return {
+    command: parseCommand(positionals[0]),
+    help: values.help === true,
+  };
 }
 
 function main(): void {
-  const command = parseCommand(process.argv[2]);
+  const parsed = parseCliArgs(process.argv.slice(2));
+  if (parsed.help) {
+    writeUsage();
+    process.exit(0);
+  }
+
+  if (parsed.command === undefined) {
+    fail(usage);
+  }
+
   const worktree = resolveWorktreeRoot();
-  const result = spawnSync("chezmoi", chezmoiCommandArgs(command, worktree), {
+  const result = spawnSync("chezmoi", commandArgs[parsed.command](worktree), {
     cwd: process.cwd(),
     stdio: "inherit",
   });
@@ -87,4 +126,6 @@ function main(): void {
   process.exit(result.status ?? 1);
 }
 
-main();
+if (import.meta.main) {
+  main();
+}


### PR DESCRIPTION
## Summary

- **worktree-dev CLI** (`scripts/worktree-dev.ts`): 4 subcommands (`context`, `diff`, `dry-run`, `apply-temp`) that run chezmoi with correct `-S`/`-W` flags for git worktrees
- **Path override support** in `reconcile-configs.ts`: parses `CHEZMOI_ARGS` for `--source`/`--working-tree` flags so the reconcile hook works inside worktrees

## Review notes

- `resolvePathOverrides` block is duplicated in `createRuntime` and `reconcileAllTools` — acceptable 3-line duplication but could extract helper if desired
- `parseCommand` calls `fail()` directly, making invalid-command paths untestable without mocking `process.exit`

## Test plan

- [x] `bun test` — 11 new tests (8 for `resolvePathOverrides`, 3 for `parseCliArgs`)
- [x] `bun run typecheck` passes
- [x] Manual: `bun run worktree:context` from a worktree prints chezmoi template vars
- [x] Manual: `bun run worktree:diff` shows correct diff from worktree source state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added developer CLI for running chezmoi against a Git worktree and four new package scripts: worktree:context, worktree:diff, worktree:dry-run, worktree:apply-temp.
  * CLI supports an apply-temp mode that emits a temporary destination path.

* **Tests**
  * Added tests covering CLI argument parsing and path-override resolution (including quoted and Windows-style paths).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->