### PR TITLE
feat(agents): add Codex CLI and OpenCode notification adapters

### DIFF
--- a/home/dot_config/opencode/plugins/notify.ts
+++ b/home/dot_config/opencode/plugins/notify.ts
@@ -19,10 +19,16 @@ const sessions = new Map<string, SessionContext>()
 // runtime/docs. Normalize the small shared shape we need for notifications.
 type PermissionLike = {
   sessionID: string
+  title?: string
   type?: string
   permission?: string
   pattern?: string | string[]
   patterns?: string[]
+}
+
+type PermissionAskedEvent = {
+  type: "permission.asked"
+  properties: PermissionLike
 }
 
 function projectName(directory: string): string {
@@ -32,6 +38,7 @@ function projectName(directory: string): string {
 
 function clip(text: string, max = 140): string {
   const trimmed = text.replace(/\s+/g, " ").trim()
+  if (max <= 3) return trimmed.slice(0, max)
   return trimmed.length > max ? `${trimmed.slice(0, max - 3)}...` : trimmed
 }
 
@@ -54,11 +61,42 @@ function idleBody(session: SessionContext): string {
 }
 
 function permissionBody(permission: PermissionLike): string {
+  if (permission.title) return permission.title
+
   const kind = permission.type ?? permission.permission ?? "permission"
   const pattern = Array.isArray(permission.pattern)
     ? permission.pattern.join(", ")
     : permission.pattern ?? permission.patterns?.join(", ") ?? "*"
   return `${kind} (${pattern})`
+}
+
+function isPermissionAskedEvent(
+  event: { type: string; properties?: unknown },
+): event is PermissionAskedEvent {
+  if (event.type !== "permission.asked") return false
+  if (typeof event.properties !== "object" || event.properties === null) return false
+  return typeof (event.properties as PermissionLike).sessionID === "string"
+}
+
+async function notify(
+  $: Parameters<Plugin>[0]["$"],
+  session: SessionContext,
+  body: string,
+): Promise<void> {
+  try {
+    await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${body}`
+  } catch (error) {
+    console.error("notify.ts: agent-notify failed", error)
+  }
+}
+
+async function notifyPermission(
+  $: Parameters<Plugin>[0]["$"],
+  permission: PermissionLike,
+): Promise<void> {
+  const session = getSession(permission.sessionID, "")
+  session.pendingPermission = permissionBody(permission)
+  await notify($, session, `Permission required: ${session.pendingPermission}`)
 }
 
 export const NotifyPlugin: Plugin = async ({ $ }) => {
@@ -85,19 +123,15 @@ export const NotifyPlugin: Plugin = async ({ $ }) => {
       }
 
       if (event.type === "permission.updated") {
-        const session = getSession(event.properties.sessionID, "")
-        session.pendingPermission = permissionBody(event.properties)
-        await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${`Permission required: ${session.pendingPermission}`}`
+        await notifyPermission($, event.properties)
         return
       }
 
       // Newer OpenCode runtimes emit `permission.asked` before the published
       // `@opencode-ai/plugin` package types fully catch up.
-      const permissionAsked = event as { type: string; properties: PermissionLike }
-      if (permissionAsked.type === "permission.asked") {
-        const session = getSession(permissionAsked.properties.sessionID, "")
-        session.pendingPermission = permissionBody(permissionAsked.properties)
-        await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${`Permission required: ${session.pendingPermission}`}`
+      const permissionAskedEvent = event as { type: string; properties?: unknown }
+      if (isPermissionAskedEvent(permissionAskedEvent)) {
+        await notifyPermission($, permissionAskedEvent.properties)
         return
       }
 
@@ -105,21 +139,25 @@ export const NotifyPlugin: Plugin = async ({ $ }) => {
         const sessionID = event.properties.sessionID
         const session = sessionID ? getSession(sessionID, "") : { project: "" }
         const body = session.lastText ? `Session error after: ${session.lastText}` : "Session error"
-        await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${body}`
-        if (sessionID) sessions.delete(sessionID)
+        try {
+          await notify($, session, body)
+        } finally {
+          if (sessionID) sessions.delete(sessionID)
+        }
         return
       }
 
       if (event.type === "session.idle") {
         const session = getSession(event.properties.sessionID, "")
-        await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${idleBody(session)}`
-        sessions.delete(event.properties.sessionID)
+        try {
+          await notify($, session, idleBody(session))
+        } finally {
+          sessions.delete(event.properties.sessionID)
+        }
       }
     },
     "permission.ask": async (input) => {
-      const session = getSession(input.sessionID, "")
-      session.pendingPermission = permissionBody(input)
-      await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${`Permission required: ${session.pendingPermission}`}`
+      await notifyPermission($, input)
     },
   }
 }

--- a/home/dot_config/opencode/plugins/notify.ts
+++ b/home/dot_config/opencode/plugins/notify.ts
@@ -11,8 +11,12 @@ type SessionContext = {
   pendingPermission?: string
 }
 
+// `session.idle` only gives `sessionID`, so keep the latest useful context here
+// and render it when the session finishes.
 const sessions = new Map<string, SessionContext>()
 
+// OpenCode permission payloads differ between published plugin types and newer
+// runtime/docs. Normalize the small shared shape we need for notifications.
 type PermissionLike = {
   sessionID: string
   type?: string
@@ -87,6 +91,8 @@ export const NotifyPlugin: Plugin = async ({ $ }) => {
         return
       }
 
+      // Newer OpenCode runtimes emit `permission.asked` before the published
+      // `@opencode-ai/plugin` package types fully catch up.
       const permissionAsked = event as { type: string; properties: PermissionLike }
       if (permissionAsked.type === "permission.asked") {
         const session = getSession(permissionAsked.properties.sessionID, "")

--- a/home/dot_config/opencode/plugins/notify.ts
+++ b/home/dot_config/opencode/plugins/notify.ts
@@ -1,0 +1,119 @@
+import type { Plugin } from "@opencode-ai/plugin"
+
+const NOTIFY_BIN = `${process.env.HOME}/.local/bin/agent-notify`
+
+type SessionContext = {
+  project: string
+  cwd?: string
+  model?: string
+  lastText?: string
+  lastTool?: string
+  pendingPermission?: string
+}
+
+const sessions = new Map<string, SessionContext>()
+
+type PermissionLike = {
+  sessionID: string
+  type?: string
+  permission?: string
+  pattern?: string | string[]
+  patterns?: string[]
+}
+
+function projectName(directory: string): string {
+  const parts = directory.replace(/[\\/]+$/, "").split(/[\\/]/)
+  return parts[parts.length - 1] ?? ""
+}
+
+function clip(text: string, max = 140): string {
+  const trimmed = text.replace(/\s+/g, " ").trim()
+  return trimmed.length > max ? `${trimmed.slice(0, max - 3)}...` : trimmed
+}
+
+function getSession(sessionID: string, project: string): SessionContext {
+  const current = sessions.get(sessionID)
+  if (current) return current
+  const created: SessionContext = { project }
+  sessions.set(sessionID, created)
+  return created
+}
+
+function titleFor(session: SessionContext): string {
+  const project = projectName(session.cwd ?? session.project) || session.project
+  return project ? `OpenCode — ${project}` : "OpenCode"
+}
+
+function idleBody(session: SessionContext): string {
+  const detail = session.lastText ?? session.lastTool ?? "Task complete"
+  return session.model ? `${session.model} · ${detail}` : detail
+}
+
+function permissionBody(permission: PermissionLike): string {
+  const kind = permission.type ?? permission.permission ?? "permission"
+  const pattern = Array.isArray(permission.pattern)
+    ? permission.pattern.join(", ")
+    : permission.pattern ?? permission.patterns?.join(", ") ?? "*"
+  return `${kind} (${pattern})`
+}
+
+export const NotifyPlugin: Plugin = async ({ $ }) => {
+  return {
+    event: async ({ event }) => {
+      if (event.type === "message.updated" && event.properties.info.role === "assistant") {
+        const info = event.properties.info
+        const session = getSession(info.sessionID, projectName(info.path.cwd))
+        session.cwd = info.path.cwd
+        session.model = `${info.providerID}/${info.modelID}`
+      }
+
+      if (event.type === "message.part.updated") {
+        const { part } = event.properties
+        const session = getSession(part.sessionID, "")
+
+        if (part.type === "text" && part.time?.end) {
+          session.lastText = clip(part.text)
+        }
+
+        if (part.type === "tool" && (part.state.status === "completed" || part.state.status === "error")) {
+          session.lastTool = `${part.tool} ${part.state.status}`
+        }
+      }
+
+      if (event.type === "permission.updated") {
+        const session = getSession(event.properties.sessionID, "")
+        session.pendingPermission = permissionBody(event.properties)
+        await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${`Permission required: ${session.pendingPermission}`}`
+        return
+      }
+
+      const permissionAsked = event as { type: string; properties: PermissionLike }
+      if (permissionAsked.type === "permission.asked") {
+        const session = getSession(permissionAsked.properties.sessionID, "")
+        session.pendingPermission = permissionBody(permissionAsked.properties)
+        await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${`Permission required: ${session.pendingPermission}`}`
+        return
+      }
+
+      if (event.type === "session.error") {
+        const sessionID = event.properties.sessionID
+        const session = sessionID ? getSession(sessionID, "") : { project: "" }
+        const body = session.lastText ? `Session error after: ${session.lastText}` : "Session error"
+        await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${body}`
+        if (sessionID) sessions.delete(sessionID)
+        return
+      }
+
+      if (event.type === "session.idle") {
+        const session = getSession(event.properties.sessionID, "")
+        await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${idleBody(session)}`
+        sessions.delete(event.properties.sessionID)
+      }
+    },
+    "permission.ask": async (input) => {
+      const session = getSession(input.sessionID, "")
+      session.pendingPermission = permissionBody(input)
+      await $`${NOTIFY_BIN} -t ${titleFor(session)} -b ${`Permission required: ${session.pendingPermission}`}`
+    },
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
     "build:notify": "bun build --compile scripts/agent-notify.ts --outfile ~/.local/bin/agent-notify",
     "reconcile:configs": "bun run scripts/reconcile-configs.ts",
     "test": "bun test",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "typecheck:opencode": "tsc --noEmit --pretty false"
   },
   "devDependencies": {
+    "@opencode-ai/plugin": "^1.4.3",
     "@types/bun": "latest",
     "typescript": "^5"
   }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "reconcile:configs": "bun run scripts/reconcile-configs.ts",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
-    "typecheck:opencode": "tsc --noEmit --pretty false"
+    "typecheck:opencode": "tsc --noEmit --pretty false",
     "worktree:context": "bun run scripts/worktree-dev.ts context",
     "worktree:diff": "bun run scripts/worktree-dev.ts diff",
     "worktree:dry-run": "bun run scripts/worktree-dev.ts dry-run",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@opencode-ai/plugin':
+        specifier: ^1.4.3
+        version: 1.4.3
       '@types/bun':
         specifier: latest
         version: 1.3.11
@@ -16,6 +19,20 @@ importers:
         version: 5.9.3
 
 packages:
+
+  '@opencode-ai/plugin@1.4.3':
+    resolution: {integrity: sha512-Ob/3tVSIeuMRJBr2O23RtrnC5djRe01Lglx+TwGEmjrH9yDBJ2tftegYLnNEjRoMuzITgq9LD8168p4pzv+U/A==}
+    peerDependencies:
+      '@opentui/core': '>=0.1.97'
+      '@opentui/solid': '>=0.1.97'
+    peerDependenciesMeta:
+      '@opentui/core':
+        optional: true
+      '@opentui/solid':
+        optional: true
+
+  '@opencode-ai/sdk@1.4.3':
+    resolution: {integrity: sha512-X0CAVbwoGAjTY2iecpWkx2B+GAa2jSaQKYpJ+xILopeF/OGKZUN15mjqci+L7cEuwLHV5wk3x2TStUOVCa5p0A==}
 
   '@types/bun@1.3.11':
     resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
@@ -26,6 +43,25 @@ packages:
   bun-types@1.3.11:
     resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
 
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
@@ -34,7 +70,24 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  zod@4.1.8:
+    resolution: {integrity: sha512-5R1P+WwQqmmMIEACyzSvo4JXHY5WiAFHRMg+zBZKgKS+Q1viRa0C1hmUKtHltoIFKtIdki3pRxkmpP74jnNYHQ==}
+
 snapshots:
+
+  '@opencode-ai/plugin@1.4.3':
+    dependencies:
+      '@opencode-ai/sdk': 1.4.3
+      zod: 4.1.8
+
+  '@opencode-ai/sdk@1.4.3':
+    dependencies:
+      cross-spawn: 7.0.6
 
   '@types/bun@1.3.11':
     dependencies:
@@ -48,6 +101,28 @@ snapshots:
     dependencies:
       '@types/node': 25.5.2
 
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  isexe@2.0.0: {}
+
+  path-key@3.1.1: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
   typescript@5.9.3: {}
 
   undici-types@7.18.2: {}
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  zod@4.1.8: {}

--- a/scripts/agent-notify.test.ts
+++ b/scripts/agent-notify.test.ts
@@ -720,12 +720,13 @@ describe("formatCodexEvent", () => {
     const payload: CodexNotifyPayload = {
       type: "custom-event",
       "thread-id": "t1",
+      cwd: "/home/user/myproject",
       "last-assistant-message": "Done working",
     };
 
     const result = formatCodexEvent(payload);
 
-    expect(result.title).toBe("Codex");
+    expect(result.title).toBe("Codex — myproject");
     expect(result.body).toBe("Done working");
     expect(result.event).toBe("custom-event");
   });

--- a/scripts/agent-notify.test.ts
+++ b/scripts/agent-notify.test.ts
@@ -4,6 +4,8 @@ import {
   buildTerminalNotification,
   buildOsc777,
   formatClaudeHook,
+  formatCodexEvent,
+  isCodexNotifyPayload,
   isEmbeddedNvimTerminal,
   notificationTypeLabel,
   parseTmuxClientInfo,
@@ -16,6 +18,7 @@ import {
   supportsOsc777ViaTmuxClientInfo,
   wrapForTmux,
   type ClaudeHookInput,
+  type CodexNotifyPayload,
   type NotificationTransport,
   type TmuxClientInfo,
 } from "./agent-notify.ts";
@@ -586,5 +589,155 @@ describe("parseArgs", () => {
 
     expect(result.title).toBe("Second");
     expect(result.body).toBe("Two");
+  });
+
+  test("defaults format to auto", () => {
+    const result = parseArgs(["Title"]);
+
+    expect(result.format).toBe("auto");
+  });
+
+  test("parses --format codex", () => {
+    const result = parseArgs(["--format", "codex"]);
+
+    expect(result.format).toBe("codex");
+  });
+
+  test("parses --format claude", () => {
+    const result = parseArgs(["--format", "claude"]);
+
+    expect(result.format).toBe("claude");
+  });
+
+  test("falls back to auto for invalid format", () => {
+    const result = parseArgs(["--format", "invalid"]);
+
+    expect(result.format).toBe("auto");
+  });
+
+  test("codex mode keeps positionals raw without title/body mapping", () => {
+    const jsonPayload = '{"type":"agent-turn-complete","thread-id":"t1"}';
+    const result = parseArgs(["--format", "codex", jsonPayload]);
+
+    expect(result.format).toBe("codex");
+    expect(result.positionals[0]).toBe(jsonPayload);
+    expect(result.title).toBeUndefined();
+  });
+
+  test("auto mode maps positionals to title/body as before", () => {
+    const result = parseArgs(["MyTitle", "MyBody"]);
+
+    expect(result.format).toBe("auto");
+    expect(result.title).toBe("MyTitle");
+    expect(result.body).toBe("MyBody");
+  });
+
+  test("exposes positionals in auto mode", () => {
+    const result = parseArgs(["Title", "Body"]);
+
+    expect(result.positionals).toEqual(["Title", "Body"]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isCodexNotifyPayload
+// ---------------------------------------------------------------------------
+
+describe("isCodexNotifyPayload", () => {
+  test("recognizes payload with thread-id", () => {
+    expect(isCodexNotifyPayload({ type: "agent-turn-complete", "thread-id": "t1" })).toBe(true);
+  });
+
+  test("recognizes payload with turn-id", () => {
+    expect(isCodexNotifyPayload({ type: "agent-turn-complete", "turn-id": "turn1" })).toBe(true);
+  });
+
+  test("recognizes payload with both", () => {
+    expect(
+      isCodexNotifyPayload({ type: "agent-turn-complete", "thread-id": "t1", "turn-id": "turn1" }),
+    ).toBe(true);
+  });
+
+  test("rejects payload without codex-specific fields", () => {
+    expect(isCodexNotifyPayload({ type: "agent-turn-complete" })).toBe(false);
+  });
+
+  test("rejects null", () => {
+    expect(isCodexNotifyPayload(null)).toBe(false);
+  });
+
+  test("rejects non-object", () => {
+    expect(isCodexNotifyPayload("string")).toBe(false);
+    expect(isCodexNotifyPayload(42)).toBe(false);
+  });
+
+  test("rejects Claude hook input (has hook_event_name, not codex fields)", () => {
+    expect(
+      isCodexNotifyPayload({ type: "Notification", hook_event_name: "Stop", session_id: "s1" }),
+    ).toBe(false);
+  });
+
+  test("rejects object with non-string type", () => {
+    expect(isCodexNotifyPayload({ type: 42, "thread-id": "t1" })).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatCodexEvent
+// ---------------------------------------------------------------------------
+
+describe("formatCodexEvent", () => {
+  test("formats agent-turn-complete with cwd", () => {
+    const payload: CodexNotifyPayload = {
+      type: "agent-turn-complete",
+      "thread-id": "t1",
+      "turn-id": "turn1",
+      cwd: "/home/user/myproject",
+    };
+
+    const result = formatCodexEvent(payload);
+
+    expect(result.title).toBe("Codex \u2014 myproject");
+    expect(result.body).toBe("Task complete");
+    expect(result.source).toBe("codex");
+    expect(result.event).toBe("agent-turn-complete");
+    expect(result.cwd).toBe("/home/user/myproject");
+  });
+
+  test("formats agent-turn-complete without cwd", () => {
+    const payload: CodexNotifyPayload = {
+      type: "agent-turn-complete",
+      "thread-id": "t1",
+    };
+
+    const result = formatCodexEvent(payload);
+
+    expect(result.title).toBe("Codex");
+    expect(result.body).toBe("Task complete");
+  });
+
+  test("formats unknown type with last-assistant-message", () => {
+    const payload: CodexNotifyPayload = {
+      type: "custom-event",
+      "thread-id": "t1",
+      "last-assistant-message": "Done working",
+    };
+
+    const result = formatCodexEvent(payload);
+
+    expect(result.title).toBe("Codex");
+    expect(result.body).toBe("Done working");
+    expect(result.event).toBe("custom-event");
+  });
+
+  test("formats unknown type without message (falls back to type)", () => {
+    const payload: CodexNotifyPayload = {
+      type: "custom-event",
+      "turn-id": "turn1",
+    };
+
+    const result = formatCodexEvent(payload);
+
+    expect(result.body).toBe("custom-event");
   });
 });

--- a/scripts/agent-notify.ts
+++ b/scripts/agent-notify.ts
@@ -22,7 +22,9 @@ export interface ClaudeHookInput {
   tool_input?: Record<string, unknown>;
 }
 
+/** Codex CLI notify payload — passed as single argv JSON argument. */
 export interface CodexNotifyPayload {
+  /** Event type. Currently only "agent-turn-complete" is supported. */
   type: string;
   "thread-id"?: string;
   "turn-id"?: string;

--- a/scripts/agent-notify.ts
+++ b/scripts/agent-notify.ts
@@ -22,6 +22,16 @@ export interface ClaudeHookInput {
   tool_input?: Record<string, unknown>;
 }
 
+export interface CodexNotifyPayload {
+  type: string;
+  "thread-id"?: string;
+  "turn-id"?: string;
+  cwd?: string;
+  "input-messages"?: string[];
+  "last-assistant-message"?: string;
+  client?: string;
+}
+
 export interface ParsedNotification {
   title: string;
   body: string;
@@ -34,6 +44,8 @@ export interface ParsedCliArgs {
   title?: string;
   body?: string;
   stdin: boolean;
+  format: "auto" | "claude" | "codex";
+  positionals: string[];
 }
 
 export interface TmuxClientInfo {
@@ -74,6 +86,40 @@ export function notificationTypeLabel(type?: string): string {
       return "Question";
     default:
       return "Notification";
+  }
+}
+
+/** Detect Codex CLI notify payloads by checking for Codex-specific fields. */
+export function isCodexNotifyPayload(value: unknown): value is CodexNotifyPayload {
+  if (typeof value !== "object" || value === null) return false;
+  const candidate = value as Partial<CodexNotifyPayload>;
+  return typeof candidate.type === "string"
+    && (typeof candidate["thread-id"] === "string"
+      || typeof candidate["turn-id"] === "string");
+}
+
+/** Format Codex CLI notify payload into a standard notification. */
+export function formatCodexEvent(payload: CodexNotifyPayload): ParsedNotification {
+  const project = projectName(payload.cwd);
+  const projectLabel = project ? ` \u2014 ${project}` : "";
+
+  switch (payload.type) {
+    case "agent-turn-complete":
+      return {
+        title: `Codex${projectLabel}`,
+        body: "Task complete",
+        source: "codex",
+        event: payload.type,
+        cwd: payload.cwd,
+      };
+    default:
+      return {
+        title: "Codex",
+        body: payload["last-assistant-message"] ?? payload.type,
+        source: "codex",
+        event: payload.type,
+        cwd: payload.cwd,
+      };
   }
 }
 
@@ -262,10 +308,18 @@ export function parseArgs(args: string[]): ParsedCliArgs {
       stdin: { type: "boolean" },
       title: { type: "string", short: "t" },
       body: { type: "string", short: "b" },
+      format: { type: "string" },
     },
     strict: false,
     allowPositionals: true,
   });
+
+  const rawFormat = stringOption(values.format as string | string[] | undefined);
+  const format: "auto" | "claude" | "codex" = rawFormat === "claude" || rawFormat === "codex" ? rawFormat : "auto";
+
+  if (format === "codex") {
+    return { stdin: !!values.stdin, format, positionals };
+  }
 
   const explicitTitle = stringOption(values.title as string | string[] | undefined);
   const explicitBody = stringOption(values.body as string | string[] | undefined);
@@ -276,6 +330,8 @@ export function parseArgs(args: string[]): ParsedCliArgs {
     stdin: !!values.stdin,
     title,
     body,
+    format,
+    positionals,
   };
 }
 
@@ -444,6 +500,17 @@ function parseNotificationFromStdin(input: string, strictJson: boolean): ParsedN
   };
 }
 
+function parseCodexArgv(argvJson: string | undefined): ParsedNotification {
+  if (!argvJson) return defaultNotification();
+  try {
+    const parsed = JSON.parse(argvJson) as unknown;
+    if (isCodexNotifyPayload(parsed)) return formatCodexEvent(parsed);
+  } catch {
+    // fall through
+  }
+  return defaultNotification();
+}
+
 function sendNotification(notification: ParsedNotification): void {
   const tmuxClientInfo = detectTmuxClientInfo();
   const transport = selectNotificationTransport(process.env, tmuxClientInfo);
@@ -475,17 +542,32 @@ export async function main(): Promise<void> {
 
   let notification: ParsedNotification;
 
-  if (parsed.stdin) {
+  if (parsed.format === "codex") {
+    notification = parseCodexArgv(parsed.positionals[0]);
+  } else if (parsed.format === "claude" || parsed.stdin) {
     notification = parseNotificationFromStdin(await readStdin(), true);
-  } else if (parsed.title) {
-    notification = {
-      title: parsed.title,
-      body: parsed.body ?? "",
-      source: "manual",
-      event: "manual",
-    };
   } else {
-    notification = parseNotificationFromStdin(await readStdin(), false);
+    // auto mode: Claude stdin → Codex argv → manual title/body → default
+    const stdinText = await readStdin();
+
+    if (stdinText.trim()) {
+      notification = parseNotificationFromStdin(stdinText, false);
+    } else if (parsed.title) {
+      // No stdin — check if title is actually a Codex JSON payload
+      const codex = parseCodexArgv(parsed.title);
+      if (codex.source === "codex") {
+        notification = codex;
+      } else {
+        notification = {
+          title: parsed.title,
+          body: parsed.body ?? "",
+          source: "manual",
+          event: "manual",
+        };
+      }
+    } else {
+      notification = defaultNotification();
+    }
   }
 
   sendNotification(notification);

--- a/scripts/agent-notify.ts
+++ b/scripts/agent-notify.ts
@@ -24,7 +24,7 @@ export interface ClaudeHookInput {
 
 /** Codex CLI notify payload — passed as single argv JSON argument. */
 export interface CodexNotifyPayload {
-  /** Event type. Currently only "agent-turn-complete" is supported. */
+  /** Event type. Known type is "agent-turn-complete", but unknown types still format generically. */
   type: string;
   "thread-id"?: string;
   "turn-id"?: string;
@@ -116,7 +116,7 @@ export function formatCodexEvent(payload: CodexNotifyPayload): ParsedNotificatio
       };
     default:
       return {
-        title: "Codex",
+        title: `Codex${projectLabel}`,
         body: payload["last-assistant-message"] ?? payload.type,
         source: "codex",
         event: payload.type,
@@ -556,7 +556,10 @@ export async function main(): Promise<void> {
       notification = parseNotificationFromStdin(stdinText, false);
     } else if (parsed.title) {
       // No stdin — check if title is actually a Codex JSON payload
-      const codex = parseCodexArgv(parsed.title);
+      const maybeCodexTitle = parsed.title.trimStart();
+      const codex = maybeCodexTitle.startsWith("{")
+        ? parseCodexArgv(parsed.title)
+        : defaultNotification();
       if (codex.source === "codex") {
         notification = codex;
       } else {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,6 @@
     "noUnusedParameters": false,
     "noPropertyAccessFromIndexSignature": false
   },
-  "include": ["scripts/**/*.ts"],
+  "include": ["scripts/**/*.ts", "home/dot_config/opencode/plugins/**/*.ts"],
   "exclude": ["node_modules", "home/dot_config/nvim", "home/AppData/Local/nvim"]
 }


### PR DESCRIPTION
## Summary
- Add Codex CLI notification support to `agent-notify` with `--format codex` flag and auto-detection of Codex JSON payloads
- Add OpenCode notification plugin (`notify.ts`) that hooks into OpenCode events and dispatches desktop notifications via `agent-notify`

## Review notes

### agent-notify.ts
- New `CodexNotifyPayload` interface with JSDoc
- `isCodexNotifyPayload` type guard discriminates on `thread-id`/`turn-id`
- `formatCodexEvent` formats `agent-turn-complete` with project name extraction
- `--format` flag: `auto|claude|codex` — auto mode chains stdin → title-as-codex-json → manual → default
- 8 new test cases covering format parsing, Codex payload detection, and event formatting

### OpenCode plugin (notify.ts)
- Tracks session context across events via `Map<string, SessionContext>`
- Handles: `message.updated`, `message.part.updated`, `permission.updated`, `permission.asked`, `session.error`, `session.idle`, `permission.ask`
- Cleans up session map on `session.idle` and `session.error`
- Uses `$` template tag for safe shell execution

## Test plan
- [x] 114 tests pass (including 8 new Codex/notification tests)
- [x] Verify `agent-notify --format codex '{"type":"agent-turn-complete","thread-id":"t1","cwd":"/tmp/proj"}'` sends notification
- [x] Verify auto-mode detects Codex JSON in title positional
- [x] Verify OpenCode plugin fires notifications on session idle/permission/error

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a notification plugin for OpenCode that sends desktop/CLI alerts, tracks session context, and surfaces permission, task-complete, and session-error notifications.
  * Enhanced notification input handling with automatic format detection and support for multiple CLI payload formats.

* **Tests**
  * Added comprehensive tests for CLI parsing, payload detection, and format-specific event formatting.

* **Chores**
  * Added a typecheck script and expanded TypeScript project includes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->