### PR TITLE
fix(agents): notify tmux clients across sessions with focus preference

### DIFF
--- a/scripts/agent-notify.test.ts
+++ b/scripts/agent-notify.test.ts
@@ -14,6 +14,7 @@ import {
   parseArgs,
   projectName,
   sanitizeOscField,
+  selectClientTargets,
   selectNotificationTransport,
   selectTmuxClientInfo,
   supportsOsc777,
@@ -755,6 +756,7 @@ describe("parseClientLine", () => {
       tty: "/dev/pts/3",
       termname: "wezterm",
       termtype: "WezTerm 20240203",
+      flags: [],
     });
   });
 
@@ -763,6 +765,16 @@ describe("parseClientLine", () => {
       tty: "/dev/pts/5",
       termname: "xterm-256color",
       termtype: "tmux-256color",
+      flags: [],
+    });
+  });
+
+  test("parses client flags when present", () => {
+    expect(parseClientLine("/dev/pts/3|wezterm|WezTerm 20240203|attached,focused,UTF-8")).toEqual({
+      tty: "/dev/pts/3",
+      termname: "wezterm",
+      termtype: "WezTerm 20240203",
+      flags: ["attached", "focused", "UTF-8"],
     });
   });
 
@@ -779,11 +791,51 @@ describe("parseClientLine", () => {
       tty: "/dev/pts/1",
       termname: "wezterm",
       termtype: "WezTerm 1",
+      flags: [],
     });
   });
 
   test("returns null when tty field is empty", () => {
     expect(parseClientLine("|wezterm|WezTerm 20240203")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// selectClientTargets
+// ---------------------------------------------------------------------------
+
+describe("selectClientTargets", () => {
+  test("prefers focused clients when present", () => {
+    const clients = [
+      { tty: "/dev/pts/1", termname: "wezterm", termtype: "WezTerm 1", flags: ["attached"] },
+      { tty: "/dev/pts/2", termname: "wezterm", termtype: "WezTerm 1", flags: ["attached", "focused"] },
+    ];
+
+    expect(selectClientTargets(clients)).toEqual([
+      { tty: "/dev/pts/2", termname: "wezterm", termtype: "WezTerm 1", flags: ["attached", "focused"] },
+    ]);
+  });
+
+  test("returns all clients when none are focused", () => {
+    const clients = [
+      { tty: "/dev/pts/1", termname: "wezterm", termtype: "WezTerm 1", flags: ["attached"] },
+      { tty: "/dev/pts/2", termname: "xterm-256color", termtype: "tmux-256color", flags: ["attached"] },
+    ];
+
+    expect(selectClientTargets(clients)).toEqual(clients);
+  });
+
+  test("supports multiple focused clients", () => {
+    const clients = [
+      { tty: "/dev/pts/1", termname: "wezterm", termtype: "WezTerm 1", flags: ["attached", "focused"] },
+      { tty: "/dev/pts/2", termname: "wezterm", termtype: "WezTerm 2", flags: ["attached", "focused"] },
+      { tty: "/dev/pts/3", termname: "wezterm", termtype: "WezTerm 3", flags: ["attached"] },
+    ];
+
+    expect(selectClientTargets(clients)).toEqual([
+      { tty: "/dev/pts/1", termname: "wezterm", termtype: "WezTerm 1", flags: ["attached", "focused"] },
+      { tty: "/dev/pts/2", termname: "wezterm", termtype: "WezTerm 2", flags: ["attached", "focused"] },
+    ]);
   });
 });
 

--- a/scripts/agent-notify.test.ts
+++ b/scripts/agent-notify.test.ts
@@ -3,11 +3,13 @@ import { describe, expect, test } from "bun:test";
 import {
   buildTerminalNotification,
   buildOsc777,
+  clientNotificationSequence,
   formatClaudeHook,
   formatCodexEvent,
   isCodexNotifyPayload,
   isEmbeddedNvimTerminal,
   notificationTypeLabel,
+  parseClientLine,
   parseTmuxClientInfo,
   parseArgs,
   projectName,
@@ -740,5 +742,101 @@ describe("formatCodexEvent", () => {
     const result = formatCodexEvent(payload);
 
     expect(result.body).toBe("custom-event");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseClientLine
+// ---------------------------------------------------------------------------
+
+describe("parseClientLine", () => {
+  test("parses valid line with tty, termname, termtype", () => {
+    expect(parseClientLine("/dev/pts/3|wezterm|WezTerm 20240203")).toEqual({
+      tty: "/dev/pts/3",
+      termname: "wezterm",
+      termtype: "WezTerm 20240203",
+    });
+  });
+
+  test("parses non-WezTerm client", () => {
+    expect(parseClientLine("/dev/pts/5|xterm-256color|tmux-256color")).toEqual({
+      tty: "/dev/pts/5",
+      termname: "xterm-256color",
+      termtype: "tmux-256color",
+    });
+  });
+
+  test("returns null for empty line", () => {
+    expect(parseClientLine("")).toBeNull();
+  });
+
+  test("returns null for separators only", () => {
+    expect(parseClientLine("||")).toBeNull();
+  });
+
+  test("trims whitespace before parsing", () => {
+    expect(parseClientLine("  /dev/pts/1|wezterm|WezTerm 1  ")).toEqual({
+      tty: "/dev/pts/1",
+      termname: "wezterm",
+      termtype: "WezTerm 1",
+    });
+  });
+
+  test("returns null when tty field is empty", () => {
+    expect(parseClientLine("|wezterm|WezTerm 20240203")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// clientNotificationSequence
+// ---------------------------------------------------------------------------
+
+describe("clientNotificationSequence", () => {
+  test("WezTerm client gets BEL + raw OSC 777", () => {
+    const seq = clientNotificationSequence("Title", "Body", {
+      termname: "wezterm",
+      termtype: "WezTerm 20240203",
+    });
+
+    expect(seq).toBe("\x07\x1b]777;notify;Title;Body\x1b\\");
+  });
+
+  test("WezTerm via termtype gets BEL + raw OSC 777", () => {
+    const seq = clientNotificationSequence("Title", "Body", {
+      termname: "xterm-256color",
+      termtype: "WezTerm 20240203",
+    });
+
+    expect(seq).toBe("\x07\x1b]777;notify;Title;Body\x1b\\");
+  });
+
+  test("non-WezTerm client gets BEL only", () => {
+    const seq = clientNotificationSequence("Title", "Body", {
+      termname: "xterm-256color",
+      termtype: "tmux-256color",
+    });
+
+    expect(seq).toBe("\x07");
+  });
+
+  test("OSC 777 is NOT DCS-wrapped (bypasses tmux)", () => {
+    const seq = clientNotificationSequence("Title", "Body", {
+      termname: "wezterm",
+      termtype: "WezTerm 20240203",
+    });
+
+    // Must NOT contain DCS passthrough prefix
+    expect(seq).not.toContain("\x1bPtmux;");
+  });
+
+  test("sanitizes title and body in OSC 777", () => {
+    const seq = clientNotificationSequence("Title;bad", "Body\x07ctrl", {
+      termname: "wezterm",
+      termtype: "WezTerm 20240203",
+    });
+
+    expect(seq).toContain("Title:bad");
+    expect(seq).not.toContain("Title;bad");
+    expect(seq).not.toContain("\x07ctrl");
   });
 });

--- a/scripts/agent-notify.ts
+++ b/scripts/agent-notify.ts
@@ -162,6 +162,26 @@ export function parseTmuxClientInfo(line: string): TmuxClientInfo | null {
   return { termname, termtype };
 }
 
+/** Parse a `tmux list-clients -F '#{client_tty}|#{client_termname}|#{client_termtype}'` line. */
+export function parseClientLine(
+  line: string,
+): { tty: string; termname: string; termtype: string } | null {
+  const [tty = "", termname = "", termtype = ""] = line.trim().split("|");
+  if (!tty) return null;
+  return { tty, termname, termtype };
+}
+
+/** Build notification bytes for one tmux client TTY. */
+export function clientNotificationSequence(
+  title: string,
+  body: string,
+  client: { termname: string; termtype: string },
+): string {
+  return supportsOsc777ViaTmuxClientInfo(client)
+    ? `${BEL}${buildOsc777(title, body)}`
+    : BEL;
+}
+
 /** Only enable WezTerm-specific OSC when every attached client for a session supports it. */
 export function selectTmuxClientInfo(clientInfos: TmuxClientInfo[]): TmuxClientInfo | null {
   if (clientInfos.length === 0) {
@@ -439,6 +459,32 @@ function writeToPath(path: string, data: string): boolean {
   }
 }
 
+/** Write notification bytes directly to every tmux client TTY (cross-session support). */
+function notifyTmuxClients(title: string, body: string): boolean {
+  if (!process.env.TMUX) return false;
+
+  const output = tmuxCapture([
+    "list-clients",
+    "-F",
+    "#{client_tty}|#{client_termname}|#{client_termtype}",
+  ]);
+  if (!output) return false;
+
+  let notified = false;
+
+  for (const line of output.split(/\r?\n/)) {
+    const client = parseClientLine(line);
+    if (!client) continue;
+    const sequence = clientNotificationSequence(title, body, client);
+
+    if (writeToPath(client.tty, sequence)) {
+      notified = true;
+    }
+  }
+
+  return notified;
+}
+
 /** Write raw bytes to the safest available terminal endpoint. */
 function writeToTerminal(data: string, transport: NotificationTransport): void {
   const paneTtyPath = currentPaneTtyPath();
@@ -514,12 +560,16 @@ function parseCodexArgv(argvJson: string | undefined): ParsedNotification {
 }
 
 function sendNotification(notification: ParsedNotification): void {
-  const tmuxClientInfo = detectTmuxClientInfo();
-  const transport = selectNotificationTransport(process.env, tmuxClientInfo);
-  writeToTerminal(
-    terminalNotificationSequence(notification.title, notification.body, transport, !!process.env.TMUX),
-    transport,
-  );
+  // Try broadcasting directly to tmux client TTYs first (cross-session support)
+  if (!notifyTmuxClients(notification.title, notification.body)) {
+    // Fallback: original behavior (agent's own controlling TTY / pane TTY)
+    const tmuxClientInfo = detectTmuxClientInfo();
+    const transport = selectNotificationTransport(process.env, tmuxClientInfo);
+    writeToTerminal(
+      terminalNotificationSequence(notification.title, notification.body, transport, !!process.env.TMUX),
+      transport,
+    );
+  }
 }
 
 

--- a/scripts/agent-notify.ts
+++ b/scripts/agent-notify.ts
@@ -55,6 +55,11 @@ export interface TmuxClientInfo {
   termtype: string;
 }
 
+export interface TmuxClientTarget extends TmuxClientInfo {
+  tty: string;
+  flags: string[];
+}
+
 export interface NotificationTransport {
   preferTmuxPaneTty: boolean;
   allowOsc777: boolean;
@@ -165,10 +170,21 @@ export function parseTmuxClientInfo(line: string): TmuxClientInfo | null {
 /** Parse a `tmux list-clients -F '#{client_tty}|#{client_termname}|#{client_termtype}'` line. */
 export function parseClientLine(
   line: string,
-): { tty: string; termname: string; termtype: string } | null {
-  const [tty = "", termname = "", termtype = ""] = line.trim().split("|");
+): TmuxClientTarget | null {
+  const [tty = "", termname = "", termtype = "", flags = ""] = line.trim().split("|");
   if (!tty) return null;
-  return { tty, termname, termtype };
+  return {
+    tty,
+    termname,
+    termtype,
+    flags: flags ? flags.split(",").filter(Boolean) : [],
+  };
+}
+
+/** Prefer focused tmux clients to reduce duplicate notifications when possible. */
+export function selectClientTargets(clients: TmuxClientTarget[]): TmuxClientTarget[] {
+  const focusedClients = clients.filter((client) => client.flags.includes("focused"));
+  return focusedClients.length > 0 ? focusedClients : clients;
 }
 
 /** Build notification bytes for one tmux client TTY. */
@@ -466,17 +482,39 @@ function notifyTmuxClients(title: string, body: string): boolean {
   const output = tmuxCapture([
     "list-clients",
     "-F",
-    "#{client_tty}|#{client_termname}|#{client_termtype}",
+    "#{client_tty}|#{client_termname}|#{client_termtype}|#{client_flags}",
   ]);
   if (!output) return false;
 
-  let notified = false;
+  const clients: TmuxClientTarget[] = [];
 
   for (const line of output.split(/\r?\n/)) {
     const client = parseClientLine(line);
     if (!client) continue;
+    clients.push(client);
+  }
+
+  if (clients.length === 0) return false;
+
+  const preferredClients = selectClientTargets(clients);
+  let notified = false;
+
+  for (const client of preferredClients) {
     const sequence = clientNotificationSequence(title, body, client);
 
+    if (writeToPath(client.tty, sequence)) {
+      notified = true;
+    }
+  }
+
+  if (notified || preferredClients.length === clients.length) {
+    return notified;
+  }
+
+  for (const client of clients) {
+    if (preferredClients.includes(client)) continue;
+
+    const sequence = clientNotificationSequence(title, body, client);
     if (writeToPath(client.tty, sequence)) {
       notified = true;
     }

--- a/scripts/agent-notify.ts
+++ b/scripts/agent-notify.ts
@@ -167,7 +167,7 @@ export function parseTmuxClientInfo(line: string): TmuxClientInfo | null {
   return { termname, termtype };
 }
 
-/** Parse a `tmux list-clients -F '#{client_tty}|#{client_termname}|#{client_termtype}'` line. */
+/** Parse a `tmux list-clients -F '#{client_tty}|#{client_termname}|#{client_termtype}|#{client_flags}'` line. */
 export function parseClientLine(
   line: string,
 ): TmuxClientTarget | null {
@@ -475,7 +475,7 @@ function writeToPath(path: string, data: string): boolean {
   }
 }
 
-/** Write notification bytes directly to every tmux client TTY (cross-session support). */
+/** Write notification bytes directly to tmux client TTYs, preferring focused clients first. */
 function notifyTmuxClients(title: string, body: string): boolean {
   if (!process.env.TMUX) return false;
 
@@ -497,6 +497,7 @@ function notifyTmuxClients(title: string, body: string): boolean {
   if (clients.length === 0) return false;
 
   const preferredClients = selectClientTargets(clients);
+  const noFocusedClients = preferredClients.length === clients.length;
   let notified = false;
 
   for (const client of preferredClients) {
@@ -507,7 +508,8 @@ function notifyTmuxClients(title: string, body: string): boolean {
     }
   }
 
-  if (notified || preferredClients.length === clients.length) {
+  // If focus filtering did not narrow the list, we already attempted every client.
+  if (notified || noFocusedClients) {
     return notified;
   }
 


### PR DESCRIPTION
## Summary
- Deliver agent notifications across tmux sessions by writing directly to tmux client TTYs via `tmux list-clients`, instead of only reaching the agent's own controlling terminal
- Prefer focused tmux clients first to reduce duplicate bells, and fall back to other clients when no focused clients exist or focused writes fail
- Fall back to original TTY behavior when not in tmux or client-TTY delivery fails

## Test plan
- [x] 103/103 unit tests pass (14 new tests for `parseClientLine`, `selectClientTargets`, `clientNotificationSequence`)
- [x] Manual: run agent in one tmux session, focus another attached client, verify notification reaches that client across sessions
- [x] Manual: run with multiple focused clients, verify each focused client receives the notification
- [x] Manual: run agent outside tmux, verify original behavior unchanged