### PR TITLE
feat(nvim): add atone.nvim undo-tree plugin

### DIFF
--- a/home/.shared-configs/nvim/lua/plugins/atone.lua
+++ b/home/.shared-configs/nvim/lua/plugins/atone.lua
@@ -1,0 +1,10 @@
+return {
+  'XXiaoA/atone.nvim',
+  cmd = 'Atone',
+  ---@module "atone"
+  ---@type AtoneConfig
+  opts = {},
+  keys = {
+    { '<leader>u', '<cmd>Atone toggle<cr>', desc = 'Undo tree' },
+  },
+}


### PR DESCRIPTION
## Summary
- Add atone.nvim lazy.nvim plugin spec.
- Lazy-load on :Atone and map <leader>u to toggle the undo tree.

## Review
- No findings in current implementation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new editor plugin with toggle functionality accessible via keyboard shortcut for convenient activation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->