### PR TITLE
fix(nvim): update opencode terminal integration

### DIFF
--- a/home/.shared-configs/nvim/lua/plugins/opencode.lua
+++ b/home/.shared-configs/nvim/lua/plugins/opencode.lua
@@ -2,7 +2,7 @@ return {
   'NickvanDyke/opencode.nvim',
   dependencies = { 'folke/snacks.nvim' },
   config = function()
-    -- https://github.com/nickjvandyke/opencode.nvim?tab=readme-ov-file#customization
+    -- https://github.com/nickjvandyke/opencode.nvim?tab=readme-ov-file#server
     local opencode_cmd = 'opencode --port'
     ---@type snacks.terminal.Opts
     local snacks_terminal_opts = {
@@ -13,10 +13,6 @@ return {
         position = 'right',
         enter = true,
         width = 0.4,
-        on_win = function(win)
-          -- Set up keymaps and cleanup for an arbitrary terminal
-          require('opencode.terminal').setup(win.win)
-        end,
       },
     }
     ---@type opencode.Opts
@@ -24,12 +20,6 @@ return {
       server = {
         start = function()
           require('snacks.terminal').open(opencode_cmd, snacks_terminal_opts)
-        end,
-        stop = function()
-          require('snacks.terminal').get(opencode_cmd, snacks_terminal_opts):close()
-        end,
-        toggle = function()
-          require('snacks.terminal').toggle(opencode_cmd, snacks_terminal_opts)
         end,
       },
     }
@@ -50,7 +40,7 @@ return {
       require('opencode').prompt('@buffer')
     end, { desc = 'Add current buffer' })
     vim.keymap.set({ 'n', 't' }, '<leader>oc', function()
-      require('opencode').toggle()
+      require('snacks.terminal').toggle(opencode_cmd, snacks_terminal_opts)
     end, { desc = 'Toggle opencode' })
 
     -- Passthrough <C-A-d> and <C-A-u> to OpenCode terminal


### PR DESCRIPTION
## Summary

- remove deprecated `opencode.terminal` setup and server lifecycle hooks
- keep Snacks terminal as custom OpenCode server starter
- toggle Snacks terminal directly from existing keymap

## Testing

- `stylua --check home/.shared-configs/nvim/lua/plugins/opencode.lua`
- headless Neovim API smoke test
- `make test` (26 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined OpenCode terminal toggle implementation and configuration structure
  * Removed unnecessary callback from terminal window options

* **Documentation**
  * Updated plugin README reference in configuration comments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->