### PR TITLE
refactor(nvim): integrate Obsidian with markdown-oxide

### DIFF
--- a/home/.shared-configs/nvim/lua/configs/lsp/markdown.lua
+++ b/home/.shared-configs/nvim/lua/configs/lsp/markdown.lua
@@ -1,5 +1,6 @@
 local LanguageSetting = require('configs.lsp.base')
 local LspConfig = require('configs.lsp.lspconfig')
+local obsidian = require('utils.obsidian')
 local M = LanguageSetting:new()
 
 M.treesitter.filetypes = { 'markdown', 'markdown_inline' }
@@ -18,8 +19,27 @@ if ok then
 end
 
 local markdown_oxide = LspConfig:new('markdown_oxide', 'markdown-oxide')
+local markdown_oxide_on_attach = assert(vim.lsp.config['markdown_oxide']).on_attach
 markdown_oxide.config = {
   capabilities = capabilities,
+  root_dir = function(bufnr, on_dir)
+    if obsidian.is_vault(bufnr) then
+      return
+    end
+
+    local path = vim.api.nvim_buf_get_name(bufnr)
+    on_dir(vim.fs.root(path, { '.git', '.moxide.toml' }) or vim.fs.dirname(path) or vim.fn.getcwd())
+  end,
+  on_attach = function(client, bufnr)
+    if obsidian.is_vault(bufnr) then
+      vim.lsp.buf_detach_client(bufnr, client.id)
+      return
+    end
+
+    if markdown_oxide_on_attach then
+      markdown_oxide_on_attach(client, bufnr)
+    end
+  end,
 }
 
 M.lspconfigs = { markdown_oxide }

--- a/home/.shared-configs/nvim/lua/configs/lsp/markdown.lua
+++ b/home/.shared-configs/nvim/lua/configs/lsp/markdown.lua
@@ -20,19 +20,40 @@ end
 
 local markdown_oxide = LspConfig:new('markdown_oxide', 'markdown-oxide')
 local markdown_oxide_on_attach = assert(vim.lsp.config['markdown_oxide']).on_attach
+
+local obsidian_lsp_capabilities = {
+  'codeActionProvider',
+  'completionProvider',
+  'definitionProvider',
+  'documentSymbolProvider',
+  'referencesProvider',
+  'renameProvider',
+  'workspaceSymbolProvider',
+}
+
 markdown_oxide.config = {
   capabilities = capabilities,
   root_dir = function(bufnr, on_dir)
-    if obsidian.is_vault(bufnr) then
+    local vault_root = obsidian.vault_root(bufnr)
+    if vault_root then
+      on_dir(vault_root)
       return
     end
 
     local path = vim.api.nvim_buf_get_name(bufnr)
     on_dir(vim.fs.root(path, { '.git', '.moxide.toml' }) or vim.fs.dirname(path) or vim.fn.getcwd())
   end,
+  reuse_client = function(client, config)
+    return client.name == config.name
+      and vim.fs.normalize(client.config.root_dir or '')
+        == vim.fs.normalize(config.root_dir or '')
+  end,
   on_attach = function(client, bufnr)
     if obsidian.is_vault(bufnr) then
-      vim.lsp.buf_detach_client(bufnr, client.id)
+      -- TODO: Remove this fallback when obsidian-ls covers the remaining markdown-oxide features.
+      for _, capability in ipairs(obsidian_lsp_capabilities) do
+        client.server_capabilities[capability] = nil
+      end
       return
     end
 

--- a/home/.shared-configs/nvim/lua/plugins/obsidian.lua
+++ b/home/.shared-configs/nvim/lua/plugins/obsidian.lua
@@ -1,60 +1,58 @@
 local obsidian = require('utils.obsidian')
 
-local function is_vault()
-  return obsidian.is_vault(0)
+---@param note obsidian.Note
+local function set_note_keymaps(note)
+  local bufnr = assert(note.bufnr)
+
+  vim.keymap.set('n', '<leader>sf', '<cmd>Obsidian quick_switch<cr>', {
+    buffer = bufnr,
+    desc = 'Obsidian: Quick switch',
+  })
+  vim.keymap.set('n', '<leader>sg', '<cmd>Obsidian search<cr>', {
+    buffer = bufnr,
+    desc = 'Obsidian: Grep notes',
+  })
 end
 
 return {
   'obsidian-nvim/obsidian.nvim',
   version = '*', -- recommended, use latest release instead of latest commit
-  ft = 'markdown',
-  cond = is_vault,
-  --- https://github.com/obsidian-nvim/obsidian.nvim/blob/main/lua/obsidian/config/default.lua
+  lazy = true,
+  init = function()
+    vim.api.nvim_create_autocmd({ 'BufReadPre', 'BufNewFile' }, {
+      pattern = '*.md',
+      callback = function(args)
+        if obsidian.is_vault(args.buf) then
+          require('lazy').load({ plugins = { 'obsidian.nvim' } })
+        end
+      end,
+    })
+  end,
+  --- https://github.com/obsidian-nvim/obsidian.nvim/wiki
   ---@module 'obsidian'
   ---@type obsidian.config
   opts = {
-    legacy_commands = false, -- this will be removed in the next major release
+    legacy_commands = false, -- removed in 4.0.0
     ui = { enable = false }, -- avoid conflict with render-markdown.nvim
     frontmatter = {
       enabled = false,
     },
-    statusline = {
+    footer = {
       enabled = false,
     },
     workspaces = {
       {
-        name = vim.fs.basename(obsidian.vault_root(0) or vim.fn.getcwd()) or 'dynamic',
+        name = 'dynamic',
         path = function()
-          return obsidian.vault_root(0) or vim.fn.getcwd()
+          return assert(obsidian.vault_root(0), 'Obsidian vault root not found')
         end,
       },
     },
-    completion = { nvim_cmp = false, blink = false },
     picker = {
-      name = 'snacks.pick',
+      name = 'snacks.picker',
     },
-    attachments = {},
-  },
-  keys = {
-    {
-      '<leader>sf',
-      function()
-        if not is_vault() then
-          return
-        end
-        vim.cmd('Obsidian quick_switch')
-      end,
-      desc = 'Obsidian: Quick switch',
-    },
-    {
-      '<leader>sg',
-      function()
-        if not is_vault() then
-          return
-        end
-        vim.cmd('Obsidian search')
-      end,
-      desc = 'Obsidian: Grep notes',
+    callbacks = {
+      enter_note = set_note_keymaps,
     },
   },
 }

--- a/home/.shared-configs/nvim/lua/plugins/obsidian.lua
+++ b/home/.shared-configs/nvim/lua/plugins/obsidian.lua
@@ -24,6 +24,7 @@ return {
       callback = function(args)
         if obsidian.is_vault(args.buf) then
           require('lazy').load({ plugins = { 'obsidian.nvim' } })
+          return true
         end
       end,
     })
@@ -32,7 +33,7 @@ return {
   ---@module 'obsidian'
   ---@type obsidian.config
   opts = {
-    legacy_commands = false, -- removed in 4.0.0
+    legacy_commands = false, -- will be removed in 4.0.0
     ui = { enable = false }, -- avoid conflict with render-markdown.nvim
     frontmatter = {
       enabled = false,

--- a/home/.shared-configs/nvim/lua/utils/obsidian.lua
+++ b/home/.shared-configs/nvim/lua/utils/obsidian.lua
@@ -24,20 +24,12 @@ function M.vault_root_from_bufname(bufname)
     limit = 1,
   })
 
-  local _, obsidian_dir = next(obsidian_dirs)
+  local obsidian_dir = obsidian_dirs[1]
   if not obsidian_dir then
     return nil
   end
 
-  local vault_root = vim.fs.dirname(obsidian_dir)
-  if not vault_root then
-    return nil
-  end
-
-  local has_workspace = vim.fn.filereadable(vault_root .. '/.obsidian/workspace.json') == 1
-    or vim.fn.filereadable(vault_root .. '/.obsidian/workspace-mobile.json') == 1
-
-  return has_workspace and vault_root or nil
+  return vim.fs.dirname(obsidian_dir)
 end
 
 ---@param bufnr? integer


### PR DESCRIPTION
## Summary

- lazy-load obsidian.nvim only for Markdown files inside an Obsidian vault
- update Obsidian options, picker integration, and vault-local keymaps
- isolate markdown-oxide clients by exact root and disable capabilities already provided by obsidian-ls inside vaults
- retain markdown-oxide-only features such as hover until obsidian-ls provides them

## Verification

- `stylua --check` on changed Lua files
- headless Neovim integration test across non-vault, vault, and non-vault buffers
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved Obsidian vault detection and markdown LSP behavior so editor features behave correctly inside vaults.
  * Plugin lazy-loads when opening vault markdown files for faster startup.
  * Streamlined note navigation, updated per-note keybindings, and switched picker integration for smoother vault browsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->