### PR TITLE
Preserve syntax highlighting in Shift-JIS Yazi previews

### DIFF
--- a/home/.shared-configs/yazi/package.toml
+++ b/home/.shared-configs/yazi/package.toml
@@ -1,7 +1,12 @@
 [[plugin.deps]]
+use = "yazi-rs/plugins:piper"
+rev = "b9598e6"
+hash = "f23ecc89ce0f9eeefdd4cea14e2a9ba7"
+
+[[plugin.deps]]
 use = "KKV9/compress"
-rev = "46a6b9f"
-hash = "771af2becc575a3f43d0542de823969d"
+rev = "e60e122"
+hash = "fbaf0adc8efc59555b748d36aab62d40"
 
 [flavor]
 deps = []

--- a/home/.shared-configs/yazi/yazi.toml
+++ b/home/.shared-configs/yazi/yazi.toml
@@ -5,16 +5,7 @@
 # Exclude "drag" to avoid intercepting terminal text selection on WSL2
 mouse_events = [ "click", "scroll" ]
 
-# Decode CP932; keep syntax highlighting for XML, XSL, and SQL.
+# Decode CP932 and use the filename to choose syntax.
 [[plugin.prepend_previewers]]
-url = "*.{xml,xsl}"
-run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --language=XML --plain --color=always --paging=never'
-
-[[plugin.prepend_previewers]]
-url = "*.sql"
-run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --language=SQL --plain --color=always --paging=never'
-
-# Decode generic .sjis text without language-specific highlighting.
-[[plugin.prepend_previewers]]
-url = "*.sjis"
-run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --plain --color=always --paging=never'
+url = "*.{xml,sql,xsl,sjis}"
+run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --file-name="$1" --map-syntax="*.xsl:XML" --plain --color=always --paging=never'

--- a/home/.shared-configs/yazi/yazi.toml
+++ b/home/.shared-configs/yazi/yazi.toml
@@ -4,3 +4,20 @@
 [mgr]
 # Exclude "drag" to avoid intercepting terminal text selection on WSL2
 mouse_events = [ "click", "scroll" ]
+
+# Decode Windows Shift-JIS (CP932), then preserve syntax highlighting.
+[[plugin.prepend_previewers]]
+url = "*.xml"
+run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --language=XML --plain --color=always --paging=never'
+
+[[plugin.prepend_previewers]]
+url = "*.sql"
+run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --language=SQL --plain --color=always --paging=never'
+
+[[plugin.prepend_previewers]]
+url = "*.xsl"
+run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --language=XML --plain --color=always --paging=never'
+
+[[plugin.prepend_previewers]]
+url = "*.sjis"
+run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --plain --color=always --paging=never'

--- a/home/.shared-configs/yazi/yazi.toml
+++ b/home/.shared-configs/yazi/yazi.toml
@@ -5,19 +5,16 @@
 # Exclude "drag" to avoid intercepting terminal text selection on WSL2
 mouse_events = [ "click", "scroll" ]
 
-# Decode Windows Shift-JIS (CP932), then preserve syntax highlighting.
+# Decode CP932; keep syntax highlighting for XML, XSL, and SQL.
 [[plugin.prepend_previewers]]
-url = "*.xml"
+url = "*.{xml,xsl}"
 run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --language=XML --plain --color=always --paging=never'
 
 [[plugin.prepend_previewers]]
 url = "*.sql"
 run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --language=SQL --plain --color=always --paging=never'
 
-[[plugin.prepend_previewers]]
-url = "*.xsl"
-run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --language=XML --plain --color=always --paging=never'
-
+# Decode generic .sjis text without language-specific highlighting.
 [[plugin.prepend_previewers]]
 url = "*.sjis"
 run = 'piper -- iconv -f CP932 -t UTF-8 -- "$1" | bat --plain --color=always --paging=never'


### PR DESCRIPTION
## Summary
- Add the locked `yazi-rs/plugins:piper` dependency.
- Decode CP932 input before rendering XML, SQL, XSL, and SJIS previews with `bat`.
- Keep the existing Yazi defaults and mouse-event override intact.

## Validation
- `pnpm test`
- `pnpm run typecheck`
- `yazi --debug` loaded the rendered config on Yazi 26.5.6.
- CP932 round-trip smoke tests produced highlighted XML and SQL output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added mouse support in Yazi, including click and scroll interactions.
  - Added UTF-8 preview support for XML, SQL, XSL, and SJIS files with syntax highlighting.

- **Chores**
  - Updated Yazi plugin configurations and refreshed an existing compression component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->